### PR TITLE
Switch AI agents to gpt-4.1-nano

### DIFF
--- a/functions/src/lib/mood-agent.ts
+++ b/functions/src/lib/mood-agent.ts
@@ -299,7 +299,7 @@ const MAX_RETRIES = 2;
 export async function runMoodAgent(
   input: MoodAgentInput,
   apiKey: string,
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-nano",
 ): Promise<AIEncouragementResponse> {
   logger.info("[MoodAgent] Starting with model:", model);
 

--- a/functions/src/lib/reflection-agent.ts
+++ b/functions/src/lib/reflection-agent.ts
@@ -57,7 +57,7 @@ function ensureAgent(apiKey: string): Agent<object, typeof reflectionOutputSchem
   cachedAgent = new Agent<object, typeof reflectionOutputSchema>({
     name: "WalkWorthyReflectionAgent",
     instructions: REFLECTION_SYSTEM_PROMPT,
-    model: "gpt-4o-mini",
+    model: "gpt-4.1-nano",
     modelSettings: { temperature: 0.6, topP: 1 },
     outputType: reflectionOutputSchema,
   });

--- a/functions/src/lib/walkworthy-agent.ts
+++ b/functions/src/lib/walkworthy-agent.ts
@@ -193,7 +193,7 @@ const MAX_RETRIES = 2;
 export async function runVerseSelectionAgent(
   input: AgentRunInput,
   apiKey: string,
-  model = "gpt-4o-mini",
+  model = "gpt-4.1-nano",
 ): Promise<VerseSelectionResult> {
   // Validate API key upfront; fail fast if missing
   const validatedApiKey = validateApiKey(apiKey);


### PR DESCRIPTION
## Summary
- Switched all three AI agents (mood, verse selection, reflection) from `gpt-4o-mini` to `gpt-4.1-nano`
- ~4x cost reduction ($0.10/$0.40 per 1M tokens vs $0.40/$1.60)
- Already deployed and live on Firebase

## Test plan
- [x] TypeScript builds clean
- [x] Functions deployed successfully to Firebase
- [ ] Verify mood check-in responses are quality
- [ ] Verify daily reflection output
- [ ] Monitor latency and costs in OpenAI dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)