### PR TITLE
feat: add Obsidian-style insights network graph to Journal tab

### DIFF
--- a/WalkWorthy/WalkWorthy/App/AppState.swift
+++ b/WalkWorthy/WalkWorthy/App/AppState.swift
@@ -35,6 +35,10 @@ final class AppState: ObservableObject {
     // MARK: - Journal State
     @Published var journalEntries: [JournalEntry] = []
 
+    // MARK: - Insights State
+    @Published var insightsNodes: [InsightsNode] = []
+    @Published var insightsLoading = false
+
     private let apiClient: any EncouragementAPI
     private let notificationScheduler: NotificationScheduler
     private let defaults: UserDefaults
@@ -444,6 +448,22 @@ final class AppState: ObservableObject {
         // Clears the in-memory list only — SwiftData store is device-local and persists across sign-outs.
         // Journal entries are not user-scoped; a fresh loadJournalEntries() after sign-in restores them.
         journalEntries = []
+    }
+
+    // MARK: - Insights
+
+    func loadInsightsData(days: Int = 90) async {
+        guard isAuthenticated, !insightsLoading else { return }
+        insightsLoading = true
+        defer { insightsLoading = false }
+        do {
+            let response = try await apiClient.fetchInsights(days: days)
+            insightsNodes = response.checkIns.map { InsightsNode(from: $0) }
+        } catch {
+            #if DEBUG
+            print("[AppState] Insights fetch failed: \(error)")
+            #endif
+        }
     }
 
     private func dailyReflectionCacheKey(for date: String) -> String {

--- a/WalkWorthy/WalkWorthy/Models/EncouragementModels.swift
+++ b/WalkWorthy/WalkWorthy/Models/EncouragementModels.swift
@@ -16,6 +16,8 @@ protocol EncouragementAPI {
     func fetchMoodHistory(days: Int, startDate: String?, endDate: String?) async throws -> MoodHistoryResponse
     func fetchDailyReflection() async throws -> DailyReflection
 
+    // Insights
+    func fetchInsights(days: Int) async throws -> InsightsResponse
 }
 
 struct RemoteUserProfileRequest: Codable {

--- a/WalkWorthy/WalkWorthy/Models/InsightsModels.swift
+++ b/WalkWorthy/WalkWorthy/Models/InsightsModels.swift
@@ -1,0 +1,144 @@
+//
+//  InsightsModels.swift
+//  WalkWorthy
+//
+//  Models for the journal insights network graph feature.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - API Response
+
+struct InsightsResponse: Codable {
+    let checkIns: [InsightsCheckIn]
+}
+
+struct InsightsCheckIn: Codable, Identifiable {
+    let id: String
+    let checkInType: String
+    let date: String
+    let timestamp: String
+    let moodScore: Int
+    let moodLevel: String
+    let emotionTags: [String]
+    let impactCategories: [String]
+
+    var checkInTypeEnum: CheckInType? {
+        CheckInType(rawValue: checkInType)
+    }
+
+    var moodLevelEnum: MoodLevel? {
+        MoodLevel(rawValue: moodLevel)
+    }
+}
+
+// MARK: - Graph Node Types
+
+/// A check-in node (small dot) in the insights graph.
+struct InsightsNode: Identifiable {
+    let id: String
+    let date: String
+    let moodScore: Int
+    let emotionTags: [String]
+    let impactCategories: [String]
+    let checkInType: CheckInType
+    var position: CGPoint = .zero
+    var velocity: CGPoint = .zero
+
+    /// Color based on mood score
+    var color: Color {
+        let level = MoodLevel.from(score: moodScore)
+        return level.sentiment.color
+    }
+
+    init(from checkIn: InsightsCheckIn) {
+        self.id = checkIn.id
+        self.date = checkIn.date
+        self.moodScore = checkIn.moodScore
+        self.emotionTags = checkIn.emotionTags
+        self.impactCategories = checkIn.impactCategories
+        self.checkInType = checkIn.checkInTypeEnum ?? .morning
+    }
+}
+
+/// A tag hub node (larger, labeled) in the insights graph.
+struct InsightsTagNode: Identifiable {
+    let id: String
+    let label: String
+    let isEmotionTag: Bool
+    var position: CGPoint = .zero
+    var velocity: CGPoint = .zero
+
+    /// Emotion tags = green, impact categories = blue-gray
+    var color: Color {
+        isEmotionTag
+            ? Color(red: 0.3, green: 0.75, blue: 0.45)
+            : Color(red: 0.55, green: 0.65, blue: 0.8)
+    }
+}
+
+/// An edge connecting a check-in node to a tag hub node.
+struct InsightsEdge: Identifiable {
+    let id: String
+    let sourceId: String  // check-in node ID
+    let targetId: String  // tag node ID
+}
+
+// MARK: - Graph Building
+
+struct InsightsGraphResult {
+    let tagNodes: [InsightsTagNode]
+    let edges: [InsightsEdge]
+}
+
+enum InsightsGraphBuilder {
+    /// Build the full graph: tag hub nodes + edges from check-ins to their tags.
+    static func buildGraph(from checkInNodes: [InsightsNode]) -> InsightsGraphResult {
+        // Collect all used emotion tags and impact categories
+        var emotionTags = Set<String>()
+        var impactCategories = Set<String>()
+        for node in checkInNodes {
+            emotionTags.formUnion(node.emotionTags)
+            impactCategories.formUnion(node.impactCategories)
+        }
+
+        // Create tag hub nodes
+        var tagNodes: [InsightsTagNode] = []
+        for tag in emotionTags {
+            tagNodes.append(InsightsTagNode(
+                id: "tag_emotion_\(tag)",
+                label: tag,
+                isEmotionTag: true
+            ))
+        }
+        for category in impactCategories {
+            tagNodes.append(InsightsTagNode(
+                id: "tag_impact_\(category)",
+                label: category,
+                isEmotionTag: false
+            ))
+        }
+
+        // Create edges: each check-in connects to each of its tags
+        var edges: [InsightsEdge] = []
+        for node in checkInNodes {
+            for tag in node.emotionTags {
+                edges.append(InsightsEdge(
+                    id: "\(node.id)_tag_emotion_\(tag)",
+                    sourceId: node.id,
+                    targetId: "tag_emotion_\(tag)"
+                ))
+            }
+            for category in node.impactCategories {
+                edges.append(InsightsEdge(
+                    id: "\(node.id)_tag_impact_\(category)",
+                    sourceId: node.id,
+                    targetId: "tag_impact_\(category)"
+                ))
+            }
+        }
+
+        return InsightsGraphResult(tagNodes: tagNodes, edges: edges)
+    }
+}

--- a/WalkWorthy/WalkWorthy/Networking/LiveAPIClient.swift
+++ b/WalkWorthy/WalkWorthy/Networking/LiveAPIClient.swift
@@ -132,6 +132,19 @@ final class LiveAPIClient: EncouragementAPI {
         return try await send(request, decode: DailyReflection.self)
     }
 
+    func fetchInsights(days: Int = 90) async throws -> InsightsResponse {
+        let queryItems = [
+            URLQueryItem(name: "insights", value: "true"),
+            URLQueryItem(name: "days", value: String(days)),
+        ]
+        let request = try await makeRequest(
+            path: "moodCheckIn",
+            method: "GET",
+            queryItems: queryItems
+        )
+        return try await send(request, decode: InsightsResponse.self)
+    }
+
     private static let isoDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"

--- a/WalkWorthy/WalkWorthy/UI/Journal/GraphSimulation.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/GraphSimulation.swift
@@ -1,0 +1,288 @@
+//
+//  GraphSimulation.swift
+//  WalkWorthy
+//
+//  Force-directed graph simulation using Verlet integration.
+//  Supports two node types: tag hubs (larger) and check-in dots (smaller).
+//
+
+import Foundation
+import SwiftUI
+
+@Observable
+final class GraphSimulation {
+    // MARK: - State
+
+    private(set) var checkInNodes: [InsightsNode] = []
+    private(set) var tagNodes: [InsightsTagNode] = []
+    private(set) var edges: [InsightsEdge] = []
+    private(set) var isSettled = true
+    private(set) var connectionCounts: [String: Int] = [:]
+
+    // MARK: - Configuration
+
+    private let repulsionStrength: CGFloat = -150
+    private let tagRepulsionStrength: CGFloat = -400  // tags repel more to spread clusters
+    private let springStrength: CGFloat = 0.008
+    private let centerStrength: CGFloat = 0.005
+    private let damping: CGFloat = 0.82
+    private let freezeThreshold: CGFloat = 0.2
+    private let maxRepulsionDistance: CGFloat = 500
+
+    // Total node count across both types
+    private var totalNodeCount: Int { checkInNodes.count + tagNodes.count }
+
+    // MARK: - Setup
+
+    func configure(
+        checkInNodes: [InsightsNode],
+        tagNodes: [InsightsTagNode],
+        edges: [InsightsEdge],
+        canvasSize: CGSize
+    ) {
+        let center = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+        let radius = min(canvasSize.width, canvasSize.height) * 0.35
+        let total = checkInNodes.count + tagNodes.count
+
+        // Place tag nodes first in an inner ring
+        var placedTags = tagNodes
+        for i in placedTags.indices {
+            let angle = (CGFloat(i) / CGFloat(max(placedTags.count, 1))) * .pi * 2
+            let r = radius * 0.5
+            placedTags[i].position = CGPoint(
+                x: center.x + cos(angle) * r,
+                y: center.y + sin(angle) * r
+            )
+            placedTags[i].velocity = .zero
+        }
+
+        // Place check-in nodes in an outer ring
+        var placedCheckIns = checkInNodes
+        for i in placedCheckIns.indices {
+            let angle = (CGFloat(i + tagNodes.count) / CGFloat(max(total, 1))) * .pi * 2
+            placedCheckIns[i].position = CGPoint(
+                x: center.x + cos(angle) * radius,
+                y: center.y + sin(angle) * radius
+            )
+            placedCheckIns[i].velocity = .zero
+        }
+
+        self.checkInNodes = placedCheckIns
+        self.tagNodes = placedTags
+        self.edges = edges
+        self.isSettled = false
+
+        // Pre-compute connection counts
+        var counts: [String: Int] = [:]
+        for edge in edges {
+            counts[edge.sourceId, default: 0] += 1
+            counts[edge.targetId, default: 0] += 1
+        }
+        self.connectionCounts = counts
+    }
+
+    func clear() {
+        checkInNodes = []
+        tagNodes = []
+        edges = []
+        isSettled = true
+    }
+
+    // MARK: - Simulation Step
+
+    func tick(canvasSize: CGSize) {
+        guard !isSettled, totalNodeCount > 0 else { return }
+
+        let center = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+        let padding: CGFloat = 30
+
+        applyRepulsion()
+        applyAttraction()
+        applyCentering(center: center)
+
+        // Integrate check-in nodes
+        var totalVelocity: CGFloat = 0
+        for i in checkInNodes.indices {
+            checkInNodes[i].velocity.x *= damping
+            checkInNodes[i].velocity.y *= damping
+            checkInNodes[i].position.x += checkInNodes[i].velocity.x
+            checkInNodes[i].position.y += checkInNodes[i].velocity.y
+            checkInNodes[i].position.x = max(padding, min(canvasSize.width - padding, checkInNodes[i].position.x))
+            checkInNodes[i].position.y = max(padding, min(canvasSize.height - padding, checkInNodes[i].position.y))
+            totalVelocity += abs(checkInNodes[i].velocity.x) + abs(checkInNodes[i].velocity.y)
+        }
+
+        // Integrate tag nodes (heavier damping — they move slower)
+        for i in tagNodes.indices {
+            tagNodes[i].velocity.x *= damping * 0.95
+            tagNodes[i].velocity.y *= damping * 0.95
+            tagNodes[i].position.x += tagNodes[i].velocity.x
+            tagNodes[i].position.y += tagNodes[i].velocity.y
+            tagNodes[i].position.x = max(padding, min(canvasSize.width - padding, tagNodes[i].position.x))
+            tagNodes[i].position.y = max(padding, min(canvasSize.height - padding, tagNodes[i].position.y))
+            totalVelocity += abs(tagNodes[i].velocity.x) + abs(tagNodes[i].velocity.y)
+        }
+
+        if totalVelocity / CGFloat(max(totalNodeCount, 1)) < freezeThreshold {
+            isSettled = true
+        }
+    }
+
+    // MARK: - Forces
+
+    private func applyRepulsion() {
+        // Check-in ↔ check-in repulsion
+        for i in 0..<checkInNodes.count {
+            for j in (i + 1)..<checkInNodes.count {
+                applyRepulsionBetween(
+                    posA: checkInNodes[i].position, posB: checkInNodes[j].position,
+                    strength: repulsionStrength
+                ) { fx, fy in
+                    checkInNodes[i].velocity.x -= fx
+                    checkInNodes[i].velocity.y -= fy
+                    checkInNodes[j].velocity.x += fx
+                    checkInNodes[j].velocity.y += fy
+                }
+            }
+        }
+
+        // Tag ↔ tag repulsion (stronger)
+        for i in 0..<tagNodes.count {
+            for j in (i + 1)..<tagNodes.count {
+                applyRepulsionBetween(
+                    posA: tagNodes[i].position, posB: tagNodes[j].position,
+                    strength: tagRepulsionStrength
+                ) { fx, fy in
+                    tagNodes[i].velocity.x -= fx
+                    tagNodes[i].velocity.y -= fy
+                    tagNodes[j].velocity.x += fx
+                    tagNodes[j].velocity.y += fy
+                }
+            }
+        }
+
+        // Check-in ↔ tag repulsion
+        for i in 0..<checkInNodes.count {
+            for j in 0..<tagNodes.count {
+                applyRepulsionBetween(
+                    posA: checkInNodes[i].position, posB: tagNodes[j].position,
+                    strength: repulsionStrength
+                ) { fx, fy in
+                    checkInNodes[i].velocity.x -= fx
+                    checkInNodes[i].velocity.y -= fy
+                    tagNodes[j].velocity.x += fx
+                    tagNodes[j].velocity.y += fy
+                }
+            }
+        }
+    }
+
+    private func applyRepulsionBetween(
+        posA: CGPoint, posB: CGPoint,
+        strength: CGFloat,
+        apply: (CGFloat, CGFloat) -> Void
+    ) {
+        let dx = posA.x - posB.x
+        let dy = posA.y - posB.y
+        let distSq = max(dx * dx + dy * dy, 1)
+        let dist = sqrt(distSq)
+        guard dist < maxRepulsionDistance else { return }
+
+        let force = strength / distSq
+        let fx = (dx / dist) * force
+        let fy = (dy / dist) * force
+        apply(fx, fy)
+    }
+
+    private func applyAttraction() {
+        // Build index for both node types
+        var checkInIndex: [String: Int] = [:]
+        for (i, node) in checkInNodes.enumerated() { checkInIndex[node.id] = i }
+        var tagIndex: [String: Int] = [:]
+        for (i, node) in tagNodes.enumerated() { tagIndex[node.id] = i }
+
+        for edge in edges {
+            // Edges go: sourceId = check-in, targetId = tag
+            guard let ci = checkInIndex[edge.sourceId],
+                  let ti = tagIndex[edge.targetId] else { continue }
+
+            let dx = tagNodes[ti].position.x - checkInNodes[ci].position.x
+            let dy = tagNodes[ti].position.y - checkInNodes[ci].position.y
+
+            let fx = dx * springStrength
+            let fy = dy * springStrength
+
+            checkInNodes[ci].velocity.x += fx
+            checkInNodes[ci].velocity.y += fy
+            tagNodes[ti].velocity.x -= fx * 0.3  // tags move less (heavier)
+            tagNodes[ti].velocity.y -= fy * 0.3
+        }
+    }
+
+    private func applyCentering(center: CGPoint) {
+        for i in checkInNodes.indices {
+            let dx = center.x - checkInNodes[i].position.x
+            let dy = center.y - checkInNodes[i].position.y
+            checkInNodes[i].velocity.x += dx * centerStrength
+            checkInNodes[i].velocity.y += dy * centerStrength
+        }
+        for i in tagNodes.indices {
+            let dx = center.x - tagNodes[i].position.x
+            let dy = center.y - tagNodes[i].position.y
+            tagNodes[i].velocity.x += dx * centerStrength
+            tagNodes[i].velocity.y += dy * centerStrength
+        }
+    }
+
+    // MARK: - Interaction
+
+    /// Hit-test: check tag nodes first (larger), then check-in nodes.
+    /// Returns either a tag node ID or check-in node ID.
+    enum HitResult {
+        case tagNode(InsightsTagNode)
+        case checkInNode(InsightsNode)
+    }
+
+    func nodeAt(_ point: CGPoint, radius: CGFloat = 30) -> HitResult? {
+        var closestDist = CGFloat.greatestFiniteMagnitude
+        var result: HitResult?
+
+        // Tag nodes get larger hit area
+        for node in tagNodes {
+            let dx = node.position.x - point.x
+            let dy = node.position.y - point.y
+            let dist = sqrt(dx * dx + dy * dy)
+            if dist < radius * 1.5 && dist < closestDist {
+                result = .tagNode(node)
+                closestDist = dist
+            }
+        }
+
+        for node in checkInNodes {
+            let dx = node.position.x - point.x
+            let dy = node.position.y - point.y
+            let dist = sqrt(dx * dx + dy * dy)
+            if dist < radius && dist < closestDist {
+                result = .checkInNode(node)
+                closestDist = dist
+            }
+        }
+
+        return result
+    }
+
+    func pinNode(id: String, to position: CGPoint) {
+        if let idx = checkInNodes.firstIndex(where: { $0.id == id }) {
+            checkInNodes[idx].position = position
+            checkInNodes[idx].velocity = .zero
+        } else if let idx = tagNodes.firstIndex(where: { $0.id == id }) {
+            tagNodes[idx].position = position
+            tagNodes[idx].velocity = .zero
+        }
+        isSettled = false
+    }
+
+    func wake() {
+        isSettled = false
+    }
+}

--- a/WalkWorthy/WalkWorthy/UI/Journal/InsightsDetailSheet.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/InsightsDetailSheet.swift
@@ -1,0 +1,232 @@
+//
+//  InsightsDetailSheet.swift
+//  WalkWorthy
+//
+//  Detail sheet shown when tapping a node in the Insights graph.
+//  Handles both tag hub nodes and check-in nodes.
+//
+
+import SwiftUI
+
+struct InsightsDetailSheet: View {
+    let hit: GraphSimulation.HitResult
+    let allCheckInNodes: [InsightsNode]
+    let edges: [InsightsEdge]
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: scaled(16)) {
+                    switch hit {
+                    case .tagNode(let tag):
+                        tagNodeContent(tag)
+                    case .checkInNode(let node):
+                        checkInNodeContent(node)
+                    }
+                }
+                .padding(scaled(20))
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text(title)
+                        .font(.newsreaderSemiBoldItalic(fixedSize: scaled(18)))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+
+    private var title: String {
+        switch hit {
+        case .tagNode(let tag): return tag.label
+        case .checkInNode: return "Check-in Details"
+        }
+    }
+
+    // MARK: - Tag Node Content
+
+    private func tagNodeContent(_ tag: InsightsTagNode) -> some View {
+        let connectedIds = Set(
+            edges.filter { $0.targetId == tag.id }.map(\.sourceId)
+        )
+        let connected = allCheckInNodes.filter { connectedIds.contains($0.id) }
+
+        return VStack(alignment: .leading, spacing: scaled(16)) {
+            // Header
+            HStack(spacing: scaled(8)) {
+                Circle()
+                    .fill(tag.color)
+                    .frame(width: scaled(14), height: scaled(14))
+                Text(tag.isEmotionTag ? "Emotion Tag" : "Impact Category")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text("\(connected.count) check-in\(connected.count == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            // Connected check-ins list
+            ForEach(connected) { node in
+                HStack(spacing: scaled(10)) {
+                    Circle()
+                        .fill(node.color)
+                        .frame(width: scaled(10), height: scaled(10))
+                    Text(Self.formatDate(node.date))
+                        .font(.subheadline)
+                    Spacer()
+                    Text("\(node.moodScore)/10")
+                        .font(.subheadline.bold())
+                        .foregroundColor(node.color)
+                    Text(node.checkInType.displayName)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, scaled(4))
+            }
+        }
+    }
+
+    // MARK: - Check-in Node Content
+
+    private func checkInNodeContent(_ node: InsightsNode) -> some View {
+        VStack(alignment: .leading, spacing: scaled(16)) {
+            // Date header
+            HStack(spacing: scaled(8)) {
+                Image(systemName: node.checkInType.iconName)
+                    .foregroundColor(node.checkInType.color)
+                Text(Self.formatDate(node.date))
+                    .font(.headline)
+                Spacer()
+                Text(node.checkInType.displayName)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            // Mood score
+            HStack(spacing: scaled(12)) {
+                Text("Mood")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text("\(node.moodScore)/10")
+                    .font(.title2.bold())
+                    .foregroundColor(node.color)
+                Circle()
+                    .fill(node.color)
+                    .frame(width: scaled(12), height: scaled(12))
+            }
+            .padding(scaled(12))
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: scaled(12)))
+
+            // Emotions
+            if !node.emotionTags.isEmpty {
+                VStack(alignment: .leading, spacing: scaled(8)) {
+                    Text("Emotions")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                    FlowLayout(spacing: scaled(6)) {
+                        ForEach(node.emotionTags, id: \.self) { tag in
+                            Text(tag)
+                                .font(.caption.weight(.medium))
+                                .padding(.horizontal, scaled(10))
+                                .padding(.vertical, scaled(6))
+                                .background(node.color.opacity(0.2))
+                                .clipShape(Capsule())
+                        }
+                    }
+                }
+            }
+
+            // Impact categories
+            if !node.impactCategories.isEmpty {
+                VStack(alignment: .leading, spacing: scaled(8)) {
+                    Text("Impact Areas")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                    FlowLayout(spacing: scaled(6)) {
+                        ForEach(node.impactCategories, id: \.self) { category in
+                            Text(category)
+                                .font(.caption.weight(.medium))
+                                .padding(.horizontal, scaled(10))
+                                .padding(.vertical, scaled(6))
+                                .background(.primary.opacity(0.1))
+                                .clipShape(Capsule())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Date Formatting
+
+    private static let isoDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    private static let displayDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f
+    }()
+
+    private static func formatDate(_ dateString: String) -> String {
+        guard let date = isoDateFormatter.date(from: dateString) else { return dateString }
+        return displayDateFormatter.string(from: date)
+    }
+}
+
+// MARK: - Flow Layout
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(
+                at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y),
+                proposal: .unspecified
+            )
+        }
+    }
+
+    private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var maxX: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth && x > 0 {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            positions.append(CGPoint(x: x, y: y))
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+            maxX = max(maxX, x)
+        }
+
+        return (CGSize(width: maxX, height: y + rowHeight), positions)
+    }
+}

--- a/WalkWorthy/WalkWorthy/UI/Journal/InsightsGraphView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/InsightsGraphView.swift
@@ -1,0 +1,313 @@
+//
+//  InsightsGraphView.swift
+//  WalkWorthy
+//
+//  Obsidian-style force-directed network graph showing all mood check-ins
+//  and their tag/category connections. Tags are hub nodes with labels,
+//  check-ins are small colored dots.
+//
+
+import SwiftUI
+
+struct InsightsGraphView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var simulation = GraphSimulation()
+    @State private var selectedHit: GraphSimulation.HitResult?
+    @State private var showingDetail = false
+    @State private var draggedNodeId: String?
+    @State private var scale: CGFloat = 1.0
+    @State private var baseScale: CGFloat = 1.0
+    @State private var offset: CGSize = .zero
+    @State private var canvasSize: CGSize = .zero
+    @State private var hasConfigured = false
+
+    var body: some View {
+        graphCanvas
+            .task {
+                await appState.loadInsightsData()
+            }
+            .sheet(isPresented: $showingDetail) {
+                if let hit = selectedHit {
+                    InsightsDetailSheet(
+                        hit: hit,
+                        allCheckInNodes: simulation.checkInNodes,
+                        edges: simulation.edges
+                    )
+                }
+            }
+    }
+
+    // MARK: - Graph Canvas
+
+    private var graphCanvas: some View {
+        GeometryReader { geo in
+            ZStack {
+                if appState.insightsLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if appState.insightsNodes.isEmpty {
+                    emptyState
+                } else {
+                    TimelineView(.animation(minimumInterval: 1.0 / 60.0, paused: simulation.isSettled)) { timeline in
+                        Canvas { context, size in
+                            drawEdges(context: &context)
+                            drawCheckInNodes(context: &context)
+                            drawTagNodes(context: &context)
+                        }
+                        .onChange(of: timeline.date) { _, _ in
+                            let wasSettled = simulation.isSettled
+                            simulation.tick(canvasSize: canvasSize)
+                            if !wasSettled && simulation.isSettled {
+                                fitGraphToCanvas()
+                            }
+                        }
+                        .gesture(tapGesture)
+                        .gesture(dragGesture)
+                        .gesture(magnifyGesture)
+                    }
+                }
+            }
+            .onAppear {
+                canvasSize = geo.size
+            }
+            .onChange(of: geo.size) { _, newSize in
+                canvasSize = newSize
+            }
+            .onChange(of: appState.insightsNodes.count) { _, _ in
+                configureGraph()
+            }
+        }
+    }
+
+    // MARK: - Drawing
+
+    private func drawEdges(context: inout GraphicsContext) {
+        for edge in simulation.edges {
+            let sourcePos = findPosition(id: edge.sourceId)
+            let targetPos = findPosition(id: edge.targetId)
+            guard let source = sourcePos, let target = targetPos else { continue }
+
+            var path = Path()
+            path.move(to: transformPoint(source))
+            path.addLine(to: transformPoint(target))
+
+            context.stroke(
+                path,
+                with: .color(.primary.opacity(0.35)),
+                lineWidth: 1
+            )
+        }
+    }
+
+    private func drawCheckInNodes(context: inout GraphicsContext) {
+        for node in simulation.checkInNodes {
+            let point = transformPoint(node.position)
+            let radius = scaled(5)
+
+            let nodeRect = CGRect(
+                x: point.x - radius,
+                y: point.y - radius,
+                width: radius * 2,
+                height: radius * 2
+            )
+            context.fill(
+                Circle().path(in: nodeRect),
+                with: .color(node.color.opacity(0.85))
+            )
+        }
+    }
+
+    private func drawTagNodes(context: inout GraphicsContext) {
+        for node in simulation.tagNodes {
+            let point = transformPoint(node.position)
+            let connections = simulation.connectionCounts[node.id] ?? 0
+            let baseRadius = scaled(16)
+            let radius = baseRadius + CGFloat(min(connections, 15)) * scaled(3)
+
+            // Glow
+            let glowRect = CGRect(
+                x: point.x - radius * 1.8,
+                y: point.y - radius * 1.8,
+                width: radius * 3.6,
+                height: radius * 3.6
+            )
+            context.fill(
+                Circle().path(in: glowRect),
+                with: .color(node.color.opacity(0.15))
+            )
+
+            // Node circle
+            let nodeRect = CGRect(
+                x: point.x - radius,
+                y: point.y - radius,
+                width: radius * 2,
+                height: radius * 2
+            )
+            context.fill(
+                Circle().path(in: nodeRect),
+                with: .color(node.color.opacity(0.6))
+            )
+            context.stroke(
+                Circle().path(in: nodeRect),
+                with: .color(node.color.opacity(0.8)),
+                lineWidth: 1
+            )
+
+            // Label text — scales with node size
+            let fontSize = scaled(9) + CGFloat(min(connections, 10)) * scaled(0.5)
+            let text = Text(node.label)
+                .font(.system(size: fontSize, weight: .semibold))
+                .foregroundColor(.primary)
+            context.draw(
+                context.resolve(text),
+                at: CGPoint(x: point.x, y: point.y + radius + scaled(8)),
+                anchor: .top
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func findPosition(id: String) -> CGPoint? {
+        if let node = simulation.checkInNodes.first(where: { $0.id == id }) {
+            return node.position
+        }
+        if let node = simulation.tagNodes.first(where: { $0.id == id }) {
+            return node.position
+        }
+        return nil
+    }
+
+    private func transformPoint(_ point: CGPoint) -> CGPoint {
+        CGPoint(
+            x: point.x * scale + offset.width,
+            y: point.y * scale + offset.height
+        )
+    }
+
+    private func inverseTransformPoint(_ point: CGPoint) -> CGPoint {
+        CGPoint(
+            x: (point.x - offset.width) / scale,
+            y: (point.y - offset.height) / scale
+        )
+    }
+
+    // MARK: - Gestures
+
+    private var tapGesture: some Gesture {
+        SpatialTapGesture()
+            .onEnded { value in
+                let simPoint = inverseTransformPoint(value.location)
+                if let hit = simulation.nodeAt(simPoint) {
+                    selectedHit = hit
+                    showingDetail = true
+                }
+            }
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 5)
+            .onChanged { value in
+                let simPoint = inverseTransformPoint(value.location)
+                if draggedNodeId == nil {
+                    if let hit = simulation.nodeAt(simPoint) {
+                        switch hit {
+                        case .tagNode(let node): draggedNodeId = node.id
+                        case .checkInNode(let node): draggedNodeId = node.id
+                        }
+                    }
+                }
+                if let id = draggedNodeId {
+                    simulation.pinNode(id: id, to: simPoint)
+                } else {
+                    offset = CGSize(
+                        width: offset.width + value.translation.width,
+                        height: offset.height + value.translation.height
+                    )
+                }
+            }
+            .onEnded { _ in
+                if draggedNodeId != nil {
+                    simulation.wake()
+                    draggedNodeId = nil
+                }
+            }
+    }
+
+    private var magnifyGesture: some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                scale = max(0.3, min(3.0, baseScale * value.magnification))
+            }
+            .onEnded { value in
+                baseScale = max(0.3, min(3.0, baseScale * value.magnification))
+            }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: scaled(16)) {
+            Image(systemName: "point.3.connected.trianglepath.dotted")
+                .font(.system(size: scaled(48)))
+                .foregroundColor(.secondary)
+
+            Text("Check in a few times to start seeing your patterns here.")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, scaled(40))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Auto-fit
+
+    private func fitGraphToCanvas() {
+        // Collect all node positions
+        let allPositions = simulation.checkInNodes.map(\.position) + simulation.tagNodes.map(\.position)
+        guard !allPositions.isEmpty else { return }
+
+        let minX = allPositions.map(\.x).min()!
+        let maxX = allPositions.map(\.x).max()!
+        let minY = allPositions.map(\.y).min()!
+        let maxY = allPositions.map(\.y).max()!
+
+        let graphWidth = maxX - minX
+        let graphHeight = maxY - minY
+        guard graphWidth > 0, graphHeight > 0 else { return }
+
+        let padding: CGFloat = scaled(60)
+        let availableWidth = canvasSize.width - padding * 2
+        let availableHeight = canvasSize.height - padding * 2
+
+        let fitScale = min(availableWidth / graphWidth, availableHeight / graphHeight, 1.5)
+
+        let centerX = (minX + maxX) / 2
+        let centerY = (minY + maxY) / 2
+
+        withAnimation(.easeInOut(duration: 0.4)) {
+            scale = fitScale
+            baseScale = fitScale
+            offset = CGSize(
+                width: canvasSize.width / 2 - centerX * fitScale,
+                height: canvasSize.height / 2 - centerY * fitScale
+            )
+        }
+    }
+
+    // MARK: - Configuration
+
+    private func configureGraph() {
+        guard !appState.insightsNodes.isEmpty, canvasSize != .zero else { return }
+
+        let graph = InsightsGraphBuilder.buildGraph(from: appState.insightsNodes)
+        simulation.configure(
+            checkInNodes: appState.insightsNodes,
+            tagNodes: graph.tagNodes,
+            edges: graph.edges,
+            canvasSize: canvasSize
+        )
+        hasConfigured = true
+    }
+}

--- a/WalkWorthy/WalkWorthy/UI/Journal/JournalTabView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/JournalTabView.swift
@@ -12,31 +12,47 @@ struct JournalTabView: View {
     @EnvironmentObject private var appState: AppState
     @State private var isShowingNewEntry = false
     @State private var errorMessage: String?
+    @State private var selectedTab: JournalViewMode = .journal
+
+    private enum JournalViewMode: String, CaseIterable {
+        case journal = "Journal"
+        case insights = "Insights"
+    }
 
     var body: some View {
-        List {
-            ForEach(appState.journalEntries) { entry in
-                NavigationLink(destination: JournalEntryView(entry: entry)) {
-                    JournalRowView(entry: entry)
+        VStack(spacing: 0) {
+            // Segmented picker
+            Picker("View", selection: $selectedTab) {
+                ForEach(JournalViewMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
                 }
             }
-            .onDelete(perform: deleteEntries)
+            .pickerStyle(.segmented)
+            .padding(.horizontal, scaled(16))
+            .padding(.vertical, scaled(8))
+
+            // Content
+            switch selectedTab {
+            case .journal:
+                journalListView
+            case .insights:
+                InsightsGraphView()
+            }
         }
-        .listStyle(.insetGrouped)
         .navigationTitle("Journal")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                Text("Journal")
+                Text(selectedTab.rawValue)
                     .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
             }
-        }
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    isShowingNewEntry = true
-                } label: {
-                    Image(systemName: "square.and.pencil")
+            if selectedTab == .journal {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        isShowingNewEntry = true
+                    } label: {
+                        Image(systemName: "square.and.pencil")
+                    }
                 }
             }
         }
@@ -52,6 +68,20 @@ struct JournalTabView: View {
                     }
             }
         }
+    }
+
+    // MARK: - Journal List
+
+    private var journalListView: some View {
+        List {
+            ForEach(appState.journalEntries) { entry in
+                NavigationLink(destination: JournalEntryView(entry: entry)) {
+                    JournalRowView(entry: entry)
+                }
+            }
+            .onDelete(perform: deleteEntries)
+        }
+        .listStyle(.insetGrouped)
         .onAppear {
             appState.loadJournalEntries(date: nil)
         }

--- a/functions/src/api/mood-checkin.ts
+++ b/functions/src/api/mood-checkin.ts
@@ -417,6 +417,12 @@ async function handleGetCheckIn(req: Request, res: Response): Promise<void> {
     const profile = await getUserProfileOnce(userId);
     const timezone = profile?.timezone || 'America/New_York';
 
+    // Check for insights query (returns full check-in data for graph visualization)
+    if (req.query.insights === 'true') {
+      const insightsDays = req.query.days ? parseInt(req.query.days as string, 10) : 90;
+      return handleGetInsights(userId, Math.min(insightsDays, 90), db, timezone, res);
+    }
+
     // Check for history query
     const historyDays = req.query.history ? parseInt(req.query.history as string, 10) : undefined;
     const startDateParam = req.query.startDate as string | undefined;
@@ -559,5 +565,73 @@ async function handleGetHistory(userId: string, days: number, db: FirebaseFirest
     });
 
     return errorResponse(res, 500, 'Failed to retrieve mood history.');
+  }
+}
+
+/**
+ * GET /moodCheckIn?insights=true&days=90
+ * Returns full check-in data (minus AI response) for graph visualization.
+ */
+async function handleGetInsights(
+  userId: string,
+  days: number,
+  db: FirebaseFirestore.Firestore,
+  timezone: string,
+  res: Response,
+): Promise<void> {
+  try {
+    const now = new Date();
+    const startDate = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    const startDateString = getDateStringInTimezone(startDate, timezone);
+
+    const checkInsQuery = await db
+      .collection(COLLECTIONS.users)
+      .doc(userId)
+      .collection('moodCheckIns')
+      .where('date', '>=', startDateString)
+      .orderBy('date', 'desc')
+      .get();
+
+    const checkIns = checkInsQuery.docs
+      .reduce<Array<{
+        id: string;
+        checkInType: CheckInType;
+        date: string;
+        timestamp: string;
+        moodScore: number;
+        moodLevel: MoodLevel;
+        emotionTags: string[];
+        impactCategories: string[];
+      }>>((acc, doc) => {
+        const data = doc.data() as MoodCheckIn;
+        if (data.moodSpectrumData) {
+          acc.push({
+            id: data.id,
+            checkInType: data.checkInType,
+            date: data.date,
+            timestamp: data.timestamp,
+            moodScore: data.moodSpectrumData.moodScore,
+            moodLevel: data.moodSpectrumData.moodLevel,
+            emotionTags: data.moodSpectrumData.emotionTags,
+            impactCategories: data.moodSpectrumData.impactCategories,
+          });
+        }
+        return acc;
+      }, []);
+
+    logger.info('Insights data retrieved', {
+      userId,
+      days,
+      count: checkIns.length,
+    });
+
+    return successResponse(res, { checkIns });
+  } catch (error) {
+    logger.error('Get insights failed', {
+      userId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+
+    return errorResponse(res, 500, 'Failed to retrieve insights data.');
   }
 }


### PR DESCRIPTION
## Summary
- Adds a force-directed network graph ("Insights" view) to the Journal tab via segmented toggle
- Tags (emotions + impact categories) appear as labeled hub nodes sized by connection count
- Check-in dots connect to their tags, forming organic clusters that reveal mood patterns
- New backend endpoint `GET /moodCheckIn?insights=true&days=90` returns full spectrum data
- Auto-fit zoom keeps the entire graph visible after simulation settles
- Works in both light and dark mode

## New files
- `InsightsModels.swift` — graph data types and builder
- `GraphSimulation.swift` — force-directed physics engine
- `InsightsGraphView.swift` — Canvas rendering with gestures
- `InsightsDetailSheet.swift` — detail views for tag and check-in taps

## Test plan
- [ ] Open Journal tab, switch to "Insights" segment
- [ ] Verify tags appear as labeled hub nodes with check-in dots connected
- [ ] Tap a tag hub → detail sheet shows connected check-ins
- [ ] Tap a check-in dot → detail sheet shows mood, emotions, impact areas
- [ ] Pinch to zoom, pan to scroll, drag nodes
- [ ] Test in both light and dark mode
- [ ] Verify graph auto-fits after settling

🤖 Generated with [Claude Code](https://claude.com/claude-code)