### PR TITLE
feat: add rate limiting and security hardening

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -180,6 +180,14 @@ service cloud.firestore {
       allow write: if false; // Only Cloud Functions can write
     }
 
+    // Internal rate-limiting and budget tracking (Cloud Functions only via Admin SDK)
+    match /_rateLimits/{document=**} {
+      allow read, write: if false;
+    }
+    match /_dailyBudgets/{document=**} {
+      allow read, write: if false;
+    }
+
     // Block everything else
     match /{document=**} {
       allow read, write: if false;

--- a/functions/src/api/daily-reflection.ts
+++ b/functions/src/api/daily-reflection.ts
@@ -13,13 +13,14 @@ import { getDb, COLLECTIONS, initializeFirebase } from "../shared/firebase";
 import { requireAuth, errorResponse, successResponse } from "../shared/auth";
 import { runReflectionAgent } from "../lib/reflection-agent";
 import type { DailyMoodSummary } from "../shared/types";
+import { checkRateLimit, checkDailyAiBudget, getClientIp, DAILY_REFLECTION_USER_LIMIT, DAILY_REFLECTION_IP_LIMIT, REFLECTION_DAILY_AI_BUDGET } from '../shared/rate-limiter';
 
 initializeFirebase();
 
 const openaiApiKey = defineSecret("openai-api-key");
 
 const httpsOptions: HttpsOptions = {
-  maxInstances: 10,
+  maxInstances: 3,
   timeoutSeconds: 60,
   invoker: "public",
   secrets: [openaiApiKey],
@@ -58,6 +59,15 @@ export const dailyReflection = onRequest(httpsOptions, async (req, res) => {
     return errorResponse(res, 405, "Method not allowed");
   }
 
+  // IP-based rate limiting
+  const db = getDb();
+  const clientIp = getClientIp(req);
+  const ipResult = await checkRateLimit(db, `ip:${clientIp}:dailyReflection`, DAILY_REFLECTION_IP_LIMIT);
+  if (!ipResult.allowed) {
+    res.set('Retry-After', String(ipResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
+
   return handleGet(req, res);
 });
 
@@ -68,6 +78,13 @@ async function handleGet(req: Request, res: Response): Promise<void> {
   const { userId } = authReq;
   const db = getDb();
   const today = resolveDate(req.query.date as string | undefined);
+
+  // User-based rate limiting
+  const userRateResult = await checkRateLimit(db, `user:${userId}:dailyReflection`, DAILY_REFLECTION_USER_LIMIT);
+  if (!userRateResult.allowed) {
+    res.set('Retry-After', String(userRateResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
 
   try {
     // Check Firestore cache first
@@ -91,6 +108,12 @@ async function handleGet(req: Request, res: Response): Promise<void> {
     const summaries: DailyMoodSummary[] = summariesSnap.docs.map(
       (d) => d.data() as DailyMoodSummary,
     );
+
+    // Check daily AI budget before calling OpenAI
+    const budgetResult = await checkDailyAiBudget(db, userId, REFLECTION_DAILY_AI_BUDGET);
+    if (!budgetResult.allowed) {
+      return errorResponse(res, 429, 'Daily reflection limit reached. Please try again tomorrow.');
+    }
 
     // Generate reflection
     const reflection = await runReflectionAgent(summaries, openaiApiKey.value());

--- a/functions/src/api/encouragement-next.ts
+++ b/functions/src/api/encouragement-next.ts
@@ -2,6 +2,12 @@ import { onRequest, HttpsOptions } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
 import { getDb, COLLECTIONS, initializeFirebase } from '../shared/firebase';
 import { requireAuth, errorResponse, successResponse } from '../shared/auth';
+import {
+  checkRateLimit,
+  getClientIp,
+  STANDARD_USER_LIMIT,
+  STANDARD_IP_LIMIT,
+} from '../shared/rate-limiter';
 
 // Initialize Firebase on module load
 initializeFirebase();
@@ -36,12 +42,27 @@ export const encouragementNext = onRequest(httpsOptions, async (req, res) => {
     return errorResponse(res, 405, `Method ${req.method} not allowed`);
   }
 
+  // IP-based rate limiting
+  const db = getDb();
+  const clientIp = getClientIp(req);
+  const ipResult = await checkRateLimit(db, `ip:${clientIp}:encouragement`, STANDARD_IP_LIMIT);
+  if (!ipResult.allowed) {
+    res.set('Retry-After', String(ipResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
+
   // Authenticate request
   const authReq = await requireAuth(req, res);
   if (!authReq) return;
 
   const { userId } = authReq;
-  const db = getDb();
+
+  // User-based rate limiting
+  const userRateResult = await checkRateLimit(db, `user:${userId}:encouragement`, STANDARD_USER_LIMIT);
+  if (!userRateResult.allowed) {
+    res.set('Retry-After', String(userRateResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
 
   try {
     const now = new Date().toISOString();
@@ -121,12 +142,27 @@ export const encouragementHistory = onRequest(httpsOptions, async (req, res) => 
     return errorResponse(res, 405, `Method ${req.method} not allowed`);
   }
 
+  // IP-based rate limiting
+  const db = getDb();
+  const clientIp = getClientIp(req);
+  const ipResult = await checkRateLimit(db, `ip:${clientIp}:encouragement`, STANDARD_IP_LIMIT);
+  if (!ipResult.allowed) {
+    res.set('Retry-After', String(ipResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
+
   // Authenticate request
   const authReq = await requireAuth(req, res);
   if (!authReq) return;
 
   const { userId } = authReq;
-  const db = getDb();
+
+  // User-based rate limiting
+  const userRateResult = await checkRateLimit(db, `user:${userId}:encouragement`, STANDARD_USER_LIMIT);
+  if (!userRateResult.allowed) {
+    res.set('Retry-After', String(userRateResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
 
   try {
     // Parse limit from query params

--- a/functions/src/api/journal.ts
+++ b/functions/src/api/journal.ts
@@ -13,6 +13,7 @@ import { logger } from 'firebase-functions/v2';
 import type { Request, Response } from 'express';
 import { getDb, COLLECTIONS, initializeFirebase } from '../shared/firebase';
 import { requireAuth, errorResponse, successResponse } from '../shared/auth';
+import { checkRateLimit, getClientIp, STANDARD_USER_LIMIT, STANDARD_IP_LIMIT } from '../shared/rate-limiter';
 import { JournalEntry } from '../shared/types';
 import { randomUUID } from 'crypto';
 
@@ -39,6 +40,26 @@ export const journal = onRequest(httpsOptions, async (req, res) => {
     path: req.path,
     hasAuthHeader: !!req.headers.authorization,
   });
+
+  // IP-based rate limiting
+  const db = getDb();
+  const clientIp = getClientIp(req);
+  const ipResult = await checkRateLimit(db, `ip:${clientIp}:journal`, STANDARD_IP_LIMIT);
+  if (!ipResult.allowed) {
+    res.set('Retry-After', String(ipResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
+
+  // Authenticate and apply user rate limit
+  const authReq = await requireAuth(req, res);
+  if (!authReq) return;
+  const { userId } = authReq;
+
+  const userRateResult = await checkRateLimit(db, `user:${userId}:journal`, STANDARD_USER_LIMIT);
+  if (!userRateResult.allowed) {
+    res.set('Retry-After', String(userRateResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
 
   // Determine if this is a sub-resource request (PATCH/DELETE /journal/:id)
   const pathSegment = req.path.replace(/^\/+/, '').replace(/\/+$/, '');

--- a/functions/src/api/mood-checkin.ts
+++ b/functions/src/api/mood-checkin.ts
@@ -29,6 +29,15 @@ import {
   PendingCheckIn,
 } from '../shared/types';
 import { randomUUID } from 'crypto';
+import {
+  checkRateLimit,
+  checkDailyAiBudget,
+  getClientIp,
+  MOOD_CHECKIN_USER_LIMIT,
+  MOOD_CHECKIN_IP_LIMIT,
+  MOOD_DAILY_AI_BUDGET,
+  STANDARD_USER_LIMIT,
+} from '../shared/rate-limiter';
 
 // Initialize Firebase on module load
 initializeFirebase();
@@ -38,7 +47,7 @@ const openaiApiKey = defineSecret('openai-api-key');
 
 const httpsOptions: HttpsOptions = {
   // CORS removed - not needed for mobile-only API (mobile apps don't enforce CORS)
-  maxInstances: 10,
+  maxInstances: 5,
   timeoutSeconds: 60, // AI calls may take time
   invoker: 'public',
   secrets: [openaiApiKey], // Bind OpenAI API key secret
@@ -170,6 +179,15 @@ export const moodCheckIn = onRequest(httpsOptions, async (req, res) => {
     hasAuthHeader: !!req.headers.authorization,
   });
 
+  // IP-based rate limiting (before auth to protect against brute force)
+  const db = getDb();
+  const clientIp = getClientIp(req);
+  const ipResult = await checkRateLimit(db, `ip:${clientIp}:moodCheckIn`, MOOD_CHECKIN_IP_LIMIT);
+  if (!ipResult.allowed) {
+    res.set('Retry-After', String(ipResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
+
   // Route based on method
   switch (req.method) {
     case 'POST':
@@ -193,7 +211,14 @@ async function handlePostCheckIn(req: Request, res: Response): Promise<void> {
   const db = getDb();
 
   try {
-    // Validate input
+    // User-based rate limiting
+    const userRateResult = await checkRateLimit(db, `user:${userId}:moodCheckIn`, MOOD_CHECKIN_USER_LIMIT);
+    if (!userRateResult.allowed) {
+      res.set('Retry-After', String(userRateResult.retryAfterSeconds));
+      return errorResponse(res, 429, 'Too many requests. Please try again later.');
+    }
+
+    // Validate input before consuming daily AI budget
     const checkInType = validateCheckInType(req.body?.checkInType);
     if (!checkInType) {
       return errorResponse(res, 400, 'Invalid check-in data. Please provide a valid checkInType.');
@@ -267,6 +292,12 @@ async function handlePostCheckIn(req: Request, res: Response): Promise<void> {
         expiresAt: transactionResult.data.expiresAt,
         isExisting: true,
       });
+    }
+
+    // Check daily AI budget before calling OpenAI
+    const budgetResult = await checkDailyAiBudget(db, userId, MOOD_DAILY_AI_BUDGET);
+    if (!budgetResult.allowed) {
+      return errorResponse(res, 429, 'Daily AI usage limit reached. Please try again tomorrow.');
     }
 
     // Step 2: Generate AI response (outside transaction - may take time)
@@ -411,6 +442,13 @@ async function handleGetCheckIn(req: Request, res: Response): Promise<void> {
 
   const { userId } = authReq;
   const db = getDb();
+
+  // User-based rate limiting for GET
+  const userRateResult = await checkRateLimit(db, `user:${userId}:moodCheckIn`, STANDARD_USER_LIMIT);
+  if (!userRateResult.allowed) {
+    res.set('Retry-After', String(userRateResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
 
   try {
     // Get user profile for timezone (needed for both history and current check-in)

--- a/functions/src/api/user-profile.ts
+++ b/functions/src/api/user-profile.ts
@@ -6,6 +6,7 @@ import { validateUserProfileInput, validateAgeRange, validateGender, validateChe
 import type { UserProfile } from '../shared/profile';
 import { clearUserProfileCache } from '../shared/profile';
 import { FieldValue } from 'firebase-admin/firestore';
+import { checkRateLimit, getClientIp, STANDARD_USER_LIMIT, STANDARD_IP_LIMIT } from '../shared/rate-limiter';
 
 // Initialize Firebase on module load
 initializeFirebase();
@@ -25,12 +26,27 @@ const httpsOptions: HttpsOptions = {
  * DELETE /user-profile - Delete user's profile
  */
 export const userProfile = onRequest(httpsOptions, async (req, res) => {
+  // IP-based rate limiting
+  const db = getDb();
+  const clientIp = getClientIp(req);
+  const ipResult = await checkRateLimit(db, `ip:${clientIp}:userProfile`, STANDARD_IP_LIMIT);
+  if (!ipResult.allowed) {
+    res.set('Retry-After', String(ipResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
+
   // Authenticate request
   const authReq = await requireAuth(req, res);
   if (!authReq) return;
 
   const { userId } = authReq;
-  const db = getDb();
+
+  // User-based rate limiting
+  const userRateResult = await checkRateLimit(db, `user:${userId}:userProfile`, STANDARD_USER_LIMIT);
+  if (!userRateResult.allowed) {
+    res.set('Retry-After', String(userRateResult.retryAfterSeconds));
+    return errorResponse(res, 429, 'Too many requests. Please try again later.');
+  }
   const profileRef = db.collection(COLLECTIONS.users).doc(userId).collection('profile').doc('data');
 
   try {

--- a/functions/src/lib/mood-agent.ts
+++ b/functions/src/lib/mood-agent.ts
@@ -283,6 +283,7 @@ function ensureAgent(
     modelSettings: {
       temperature: 0.4,
       topP: 1,
+      maxTokens: 512,
     },
     outputType: encouragementOutputSchema,
     outputGuardrails: [piiGuardrail],

--- a/functions/src/lib/reflection-agent.ts
+++ b/functions/src/lib/reflection-agent.ts
@@ -58,7 +58,7 @@ function ensureAgent(apiKey: string): Agent<object, typeof reflectionOutputSchem
     name: "WalkWorthyReflectionAgent",
     instructions: REFLECTION_SYSTEM_PROMPT,
     model: "gpt-4.1-nano",
-    modelSettings: { temperature: 0.6, topP: 1 },
+    modelSettings: { temperature: 0.6, topP: 1, maxTokens: 256 },
     outputType: reflectionOutputSchema,
   });
 

--- a/functions/src/shared/rate-limiter.ts
+++ b/functions/src/shared/rate-limiter.ts
@@ -1,0 +1,153 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import type { Request } from 'express';
+import { logger } from 'firebase-functions/v2';
+
+export interface RateLimitConfig {
+  maxRequests: number;
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSeconds: number;
+}
+
+export interface DailyBudgetResult {
+  allowed: boolean;
+  remaining: number;
+}
+
+interface RateLimitDoc {
+  timestamps: string[];
+  updatedAt: string;
+}
+
+interface DailyBudgetDoc {
+  callCount: number;
+  date: string;
+}
+
+// AI endpoints (expensive)
+export const MOOD_CHECKIN_USER_LIMIT: RateLimitConfig = { maxRequests: 10, windowMs: 3600000 };
+export const MOOD_CHECKIN_IP_LIMIT: RateLimitConfig = { maxRequests: 30, windowMs: 3600000 };
+export const DAILY_REFLECTION_USER_LIMIT: RateLimitConfig = { maxRequests: 5, windowMs: 3600000 };
+export const DAILY_REFLECTION_IP_LIMIT: RateLimitConfig = { maxRequests: 20, windowMs: 3600000 };
+
+// Standard endpoints
+export const STANDARD_USER_LIMIT: RateLimitConfig = { maxRequests: 30, windowMs: 3600000 };
+export const STANDARD_IP_LIMIT: RateLimitConfig = { maxRequests: 60, windowMs: 3600000 };
+
+// Daily AI budgets
+export const MOOD_DAILY_AI_BUDGET = 15;
+export const REFLECTION_DAILY_AI_BUDGET = 5;
+
+/**
+ * Sliding window rate limiter backed by Firestore.
+ * Stores ISO timestamps of recent requests and filters out expired ones.
+ */
+export async function checkRateLimit(
+  db: Firestore,
+  key: string,
+  config: RateLimitConfig
+): Promise<RateLimitResult> {
+  const docRef = db.collection('_rateLimits').doc(key);
+  const now = Date.now();
+  const windowStart = now - config.windowMs;
+
+  try {
+    return await db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      const data = snap.exists ? (snap.data() as RateLimitDoc) : null;
+
+      const allTimestamps: string[] = data?.timestamps ?? [];
+      const windowTimestamps = allTimestamps.filter(
+        (ts) => new Date(ts).getTime() > windowStart
+      );
+
+      if (windowTimestamps.length >= config.maxRequests) {
+        const oldestInWindow = windowTimestamps.reduce((min, ts) => {
+          const t = new Date(ts).getTime();
+          return t < min ? t : min;
+        }, Infinity);
+        const retryAfterMs = oldestInWindow + config.windowMs - now;
+        const retryAfterSeconds = Math.ceil(Math.max(retryAfterMs, 0) / 1000);
+        return { allowed: false, retryAfterSeconds };
+      }
+
+      const nowIso = new Date(now).toISOString();
+      const updatedTimestamps = [...windowTimestamps, nowIso];
+      const updatedDoc: RateLimitDoc = {
+        timestamps: updatedTimestamps,
+        updatedAt: nowIso,
+      };
+      tx.set(docRef, updatedDoc);
+
+      return { allowed: true, retryAfterSeconds: 0 };
+    });
+  } catch (err) {
+    logger.error('checkRateLimit transaction failed', { key, err });
+    // Fail open to avoid blocking legitimate requests on Firestore errors
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+}
+
+/**
+ * Daily AI budget counter backed by Firestore.
+ * Tracks per-user call counts scoped to a UTC calendar day.
+ */
+export async function checkDailyAiBudget(
+  db: Firestore,
+  userId: string,
+  maxCallsPerDay: number
+): Promise<DailyBudgetResult> {
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
+  const docId = `${userId}_${today}`;
+  const docRef = db.collection('_dailyBudgets').doc(docId);
+
+  try {
+    return await db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+
+      if (!snap.exists) {
+        const newDoc: DailyBudgetDoc = { callCount: 1, date: today };
+        tx.set(docRef, newDoc);
+        return { allowed: true, remaining: maxCallsPerDay - 1 };
+      }
+
+      const data = snap.data() as DailyBudgetDoc;
+
+      if (data.date !== today) {
+        // Stale document from a previous day — reset
+        const resetDoc: DailyBudgetDoc = { callCount: 1, date: today };
+        tx.set(docRef, resetDoc);
+        return { allowed: true, remaining: maxCallsPerDay - 1 };
+      }
+
+      if (data.callCount >= maxCallsPerDay) {
+        return { allowed: false, remaining: 0 };
+      }
+
+      const updatedCount = data.callCount + 1;
+      tx.update(docRef, { callCount: updatedCount });
+      return { allowed: true, remaining: maxCallsPerDay - updatedCount };
+    });
+  } catch (err) {
+    logger.error('checkDailyAiBudget transaction failed', { userId, err });
+    // Fail open to avoid blocking legitimate requests on Firestore errors
+    return { allowed: true, remaining: 0 };
+  }
+}
+
+/**
+ * Extracts the client IP from an Express request.
+ * Prefers the first address in X-Forwarded-For, falls back to req.ip.
+ */
+export function getClientIp(req: Request): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) {
+    const raw = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+    const first = raw.split(',')[0].trim();
+    if (first) return first;
+  }
+  return req.ip ?? 'unknown';
+}


### PR DESCRIPTION
## Summary
- **Rate limiting**: Firestore-backed sliding window rate limiter (per-user + per-IP) on all 6 API endpoints. AI endpoints get tighter limits (10/hr mood, 5/hr reflection) vs standard endpoints (30/hr)
- **OpenAI cost controls**: `maxTokens` on both AI agents (512 mood, 256 reflection) + per-user daily AI call budgets (15/day mood, 5/day reflection)
- **Infrastructure hardening**: Reduced `maxInstances` on expensive endpoints (mood→5, reflection→3), blocked internal collections in Firestore rules

## Changes
| File | Change |
|------|--------|
| `functions/src/shared/rate-limiter.ts` | **New** — rate limiter, daily budget counter, IP extraction, config constants |
| `functions/src/api/mood-checkin.ts` | IP+user rate limits, daily AI budget, maxInstances: 5 |
| `functions/src/api/daily-reflection.ts` | IP+user rate limits, daily AI budget, maxInstances: 3 |
| `functions/src/api/user-profile.ts` | IP+user rate limits |
| `functions/src/api/journal.ts` | IP+user rate limits |
| `functions/src/api/encouragement-next.ts` | IP+user rate limits (both endpoints) |
| `functions/src/lib/mood-agent.ts` | Added `maxTokens: 512` |
| `functions/src/lib/reflection-agent.ts` | Added `maxTokens: 256` |
| `firestore.rules` | Deny rules for `_rateLimits` and `_dailyBudgets` collections |

## Design decisions
- Rate limiter fails **open** (allows on Firestore error) to avoid blocking legitimate users
- IP rate limit runs **before** auth to protect against unauthenticated brute force
- Input validation runs **before** daily budget check so invalid requests don't burn budget
- Firebase App Check deferred — `consumeAppCheckToken` only works with `onCall`, not `onRequest`

## Test plan
- [ ] `cd functions && npm run build` compiles clean
- [ ] Deploy to emulator and verify all endpoints return 429 after exceeding rate limits
- [ ] Verify mood check-in still returns valid AI responses (maxTokens not truncating)
- [ ] Verify daily budget resets at UTC midnight
- [ ] Verify `_rateLimits` collection blocked from client SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)