### PR TITLE
feat: add Firebase App Check enforcement

### DIFF
--- a/WalkWorthy/WalkWorthy.xcodeproj/project.pbxproj
+++ b/WalkWorthy/WalkWorthy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2FCA27BD2F01E38F002FFC6A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 2FCA27BC2F01E38F002FFC6A /* FirebaseAuth */; };
+		2FCA27BF2F01E38F002FFC6A /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 2FCA27BE2F01E38F002FFC6A /* FirebaseAppCheck */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +42,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FCA27BD2F01E38F002FFC6A /* FirebaseAuth in Frameworks */,
+				2FCA27BF2F01E38F002FFC6A /* FirebaseAppCheck in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +94,7 @@
 			name = WalkWorthy;
 			packageProductDependencies = (
 				2FCA27BC2F01E38F002FFC6A /* FirebaseAuth */,
+				2FCA27BE2F01E38F002FFC6A /* FirebaseAppCheck */,
 			);
 			productName = WalkWorthy;
 			productReference = 2F5AB6162E90FD8F00333B8C /* WalkWorthy.app */;
@@ -386,6 +389,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2F3DAE502F01D37B00B35947 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
+		};
+		2FCA27BE2F01E38F002FFC6A /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F3DAE502F01D37B00B35947 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WalkWorthy/WalkWorthy/App/WalkWorthyApp.swift
+++ b/WalkWorthy/WalkWorthy/App/WalkWorthyApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import UIKit
 import UserNotifications
 import FirebaseCore
+import FirebaseAppCheck
 import SwiftData
 
 @main
@@ -21,6 +22,12 @@ struct WalkWorthyApp: App {
     private let container: ModelContainer
 
     init() {
+        #if DEBUG
+        AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())
+        #else
+        AppCheck.setAppCheckProviderFactory(AppAttestProviderFactory())
+        #endif
+
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
         }
@@ -32,7 +39,7 @@ struct WalkWorthyApp: App {
         #endif
 
         let authSession = FirebaseAuthSession()
-        guard let liveClient = LiveAPIClient(config: resolvedConfig, tokenProvider: authSession) else {
+        guard let liveClient = LiveAPIClient(config: resolvedConfig, tokenProvider: authSession, appCheckProvider: authSession) else {
             fatalError("API_BASE_URL is not configured")
         }
 

--- a/WalkWorthy/WalkWorthy/Auth/AppCheckTokenProviding.swift
+++ b/WalkWorthy/WalkWorthy/Auth/AppCheckTokenProviding.swift
@@ -1,0 +1,12 @@
+//
+//  AppCheckTokenProviding.swift
+//  WalkWorthy
+//
+//  Abstraction for fetching Firebase App Check tokens.
+//
+
+import Foundation
+
+protocol AppCheckTokenProviding: Sendable {
+    func validAppCheckToken() async throws -> String
+}

--- a/WalkWorthy/WalkWorthy/Auth/FirebaseAuthSession.swift
+++ b/WalkWorthy/WalkWorthy/Auth/FirebaseAuthSession.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 import FirebaseAuth
+import FirebaseAppCheck
 
-actor FirebaseAuthSession: BearerTokenProviding {
+actor FirebaseAuthSession: BearerTokenProviding, AppCheckTokenProviding {
     enum AuthError: LocalizedError, Sendable {
         case notAuthenticated
         case tokenFetchFailed(String)
@@ -45,6 +46,13 @@ actor FirebaseAuthSession: BearerTokenProviding {
         } catch {
             throw AuthError.tokenFetchFailed(error.localizedDescription)
         }
+    }
+
+    // MARK: - AppCheckTokenProviding
+
+    func validAppCheckToken() async throws -> String {
+        let result = try await AppCheck.appCheck().token(forcingRefresh: false)
+        return result.token
     }
 
     // MARK: - Public Methods

--- a/WalkWorthy/WalkWorthy/Networking/LiveAPIClient.swift
+++ b/WalkWorthy/WalkWorthy/Networking/LiveAPIClient.swift
@@ -10,16 +10,18 @@ import Foundation
 final class LiveAPIClient: EncouragementAPI {
     private let baseURL: URL
     private let tokenProvider: BearerTokenProviding
+    private let appCheckProvider: AppCheckTokenProviding
     private let urlSession: URLSession
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
 
-    init?(config: Config, tokenProvider: BearerTokenProviding, urlSession: URLSession = .shared) {
+    init?(config: Config, tokenProvider: BearerTokenProviding, appCheckProvider: AppCheckTokenProviding, urlSession: URLSession = .shared) {
         guard let baseURL = config.apiBaseURL else {
             return nil
         }
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
+        self.appCheckProvider = appCheckProvider
         self.urlSession = urlSession
         self.decoder = JSONDecoder()
         self.decoder.dateDecodingStrategy = .iso8601
@@ -180,6 +182,15 @@ final class LiveAPIClient: EncouragementAPI {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         } catch {
             throw APIError.notAuthenticated
+        }
+
+        do {
+            let appCheckToken = try await appCheckProvider.validAppCheckToken()
+            request.setValue(appCheckToken, forHTTPHeaderField: "X-Firebase-AppCheck")
+        } catch {
+            #if DEBUG
+            print("[LiveAPIClient] App Check token fetch failed: \(error)")
+            #endif
         }
 
         return request

--- a/functions/src/api/daily-reflection.ts
+++ b/functions/src/api/daily-reflection.ts
@@ -10,7 +10,7 @@ import { defineSecret } from "firebase-functions/params";
 import { logger } from "firebase-functions/v2";
 import type { Request, Response } from "express";
 import { getDb, COLLECTIONS, initializeFirebase } from "../shared/firebase";
-import { requireAuth, errorResponse, successResponse } from "../shared/auth";
+import { requireAuth, verifyAppCheck, errorResponse, successResponse } from "../shared/auth";
 import { runReflectionAgent } from "../lib/reflection-agent";
 import type { DailyMoodSummary } from "../shared/types";
 import { checkRateLimit, checkDailyAiBudget, getClientIp, DAILY_REFLECTION_USER_LIMIT, DAILY_REFLECTION_IP_LIMIT, REFLECTION_DAILY_AI_BUDGET } from '../shared/rate-limiter';
@@ -58,6 +58,10 @@ export const dailyReflection = onRequest(httpsOptions, async (req, res) => {
     res.setHeader("Allow", "GET");
     return errorResponse(res, 405, "Method not allowed");
   }
+
+  // App Check verification
+  const appCheckValid = await verifyAppCheck(req, res);
+  if (!appCheckValid) return;
 
   // IP-based rate limiting
   const db = getDb();

--- a/functions/src/api/encouragement-next.ts
+++ b/functions/src/api/encouragement-next.ts
@@ -1,7 +1,7 @@
 import { onRequest, HttpsOptions } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
 import { getDb, COLLECTIONS, initializeFirebase } from '../shared/firebase';
-import { requireAuth, errorResponse, successResponse } from '../shared/auth';
+import { requireAuth, verifyAppCheck, errorResponse, successResponse } from '../shared/auth';
 import {
   checkRateLimit,
   getClientIp,
@@ -41,6 +41,10 @@ export const encouragementNext = onRequest(httpsOptions, async (req, res) => {
     res.setHeader('Allow', 'GET');
     return errorResponse(res, 405, `Method ${req.method} not allowed`);
   }
+
+  // App Check verification
+  const appCheckValid = await verifyAppCheck(req, res);
+  if (!appCheckValid) return;
 
   // IP-based rate limiting
   const db = getDb();
@@ -141,6 +145,10 @@ export const encouragementHistory = onRequest(httpsOptions, async (req, res) => 
     res.setHeader('Allow', 'GET');
     return errorResponse(res, 405, `Method ${req.method} not allowed`);
   }
+
+  // App Check verification
+  const appCheckValid = await verifyAppCheck(req, res);
+  if (!appCheckValid) return;
 
   // IP-based rate limiting
   const db = getDb();

--- a/functions/src/api/journal.ts
+++ b/functions/src/api/journal.ts
@@ -12,7 +12,7 @@ import { onRequest, HttpsOptions } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
 import type { Request, Response } from 'express';
 import { getDb, COLLECTIONS, initializeFirebase } from '../shared/firebase';
-import { requireAuth, errorResponse, successResponse } from '../shared/auth';
+import { requireAuth, verifyAppCheck, errorResponse, successResponse } from '../shared/auth';
 import { checkRateLimit, getClientIp, STANDARD_USER_LIMIT, STANDARD_IP_LIMIT } from '../shared/rate-limiter';
 import { JournalEntry } from '../shared/types';
 import { randomUUID } from 'crypto';
@@ -40,6 +40,10 @@ export const journal = onRequest(httpsOptions, async (req, res) => {
     path: req.path,
     hasAuthHeader: !!req.headers.authorization,
   });
+
+  // App Check verification
+  const appCheckValid = await verifyAppCheck(req, res);
+  if (!appCheckValid) return;
 
   // IP-based rate limiting
   const db = getDb();

--- a/functions/src/api/mood-checkin.ts
+++ b/functions/src/api/mood-checkin.ts
@@ -12,7 +12,7 @@ import { defineSecret } from 'firebase-functions/params';
 import { logger } from 'firebase-functions/v2';
 import type { Request, Response } from 'express';
 import { getDb, COLLECTIONS, initializeFirebase } from '../shared/firebase';
-import { requireAuth, errorResponse, successResponse } from '../shared/auth';
+import { requireAuth, verifyAppCheck, errorResponse, successResponse } from '../shared/auth';
 import { getUserProfileOnce } from '../shared/profile';
 import { runMoodAgent, UserProfilePayload, MoodAgentInput } from '../lib/mood-agent';
 import {
@@ -178,6 +178,10 @@ export const moodCheckIn = onRequest(httpsOptions, async (req, res) => {
     path: req.path,
     hasAuthHeader: !!req.headers.authorization,
   });
+
+  // App Check verification
+  const appCheckValid = await verifyAppCheck(req, res);
+  if (!appCheckValid) return;
 
   // IP-based rate limiting (before auth to protect against brute force)
   const db = getDb();

--- a/functions/src/api/user-profile.ts
+++ b/functions/src/api/user-profile.ts
@@ -1,7 +1,7 @@
 import { onRequest, HttpsOptions } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
 import { getDb, COLLECTIONS, initializeFirebase } from '../shared/firebase';
-import { requireAuth, errorResponse, successResponse } from '../shared/auth';
+import { requireAuth, verifyAppCheck, errorResponse, successResponse } from '../shared/auth';
 import { validateUserProfileInput, validateAgeRange, validateGender, validateCheckInTimes } from '../shared/types';
 import type { UserProfile } from '../shared/profile';
 import { clearUserProfileCache } from '../shared/profile';
@@ -26,6 +26,10 @@ const httpsOptions: HttpsOptions = {
  * DELETE /user-profile - Delete user's profile
  */
 export const userProfile = onRequest(httpsOptions, async (req, res) => {
+  // App Check verification
+  const appCheckValid = await verifyAppCheck(req, res);
+  if (!appCheckValid) return;
+
   // IP-based rate limiting
   const db = getDb();
   const clientIp = getClientIp(req);

--- a/functions/src/shared/auth.ts
+++ b/functions/src/shared/auth.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { logger } from "firebase-functions/v2";
 import http from "http";
-import { getAuthInstance } from "./firebase";
+import { getAuthInstance, getAppCheckInstance } from "./firebase";
 import { DecodedIdToken } from "firebase-admin/auth";
 
 /**
@@ -73,6 +73,36 @@ export async function requireAuth(
   authReq.userId = decodedToken.uid;
 
   return authReq;
+}
+
+/**
+ * Verify Firebase App Check token from X-Firebase-AppCheck header.
+ *
+ * @param req - Express request object
+ * @param res - Express response object
+ * @returns true if valid, false if rejected (response already sent)
+ */
+export async function verifyAppCheck(
+  req: Request,
+  res: Response
+): Promise<boolean> {
+  const token = req.headers['x-firebase-appcheck'];
+  if (!token || typeof token !== 'string') {
+    errorResponse(res, 401, 'Missing App Check token');
+    return false;
+  }
+
+  try {
+    const appCheck = getAppCheckInstance();
+    await appCheck.verifyToken(token);
+    return true;
+  } catch (error) {
+    logger.warn('App Check verification failed', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    errorResponse(res, 401, 'Invalid App Check token');
+    return false;
+  }
 }
 
 /**

--- a/functions/src/shared/firebase.ts
+++ b/functions/src/shared/firebase.ts
@@ -1,10 +1,12 @@
 import { initializeApp, getApps, App } from 'firebase-admin/app';
 import { getFirestore, Firestore } from 'firebase-admin/firestore';
 import { getAuth, Auth } from 'firebase-admin/auth';
+import { getAppCheck, AppCheck } from 'firebase-admin/app-check';
 
 let app: App | undefined;
 let firestoreInstance: Firestore | undefined;
 let authInstance: Auth | undefined;
+let appCheckInstance: AppCheck | undefined;
 
 /**
  * Initialize Firebase Admin SDK.
@@ -43,6 +45,17 @@ export function getAuthInstance(): Auth {
   initializeFirebase();
   authInstance = getAuth();
   return authInstance;
+}
+
+/**
+ * Get Firebase App Check instance.
+ * Automatically initializes Firebase if needed.
+ */
+export function getAppCheckInstance(): AppCheck {
+  if (appCheckInstance) return appCheckInstance;
+  initializeFirebase();
+  appCheckInstance = getAppCheck();
+  return appCheckInstance;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds App Check token verification to all 5 backend API endpoints (runs before IP rate limiting)
- Configures iOS app with App Attest (production) and debug provider (development)
- Attaches `X-Firebase-AppCheck` header to every API request via `LiveAPIClient`
- New `AppCheckTokenProviding` protocol for clean dependency injection

## Manual steps required after merge
1. **Firebase Console** → App Check → Register iOS app with **App Attest** provider
2. Run the app in debug mode, copy the debug token from Xcode console, and register it in Firebase Console for local testing

## Files changed
| Area | Files |
|------|-------|
| Backend middleware | `shared/firebase.ts`, `shared/auth.ts` |
| Backend endpoints | All 5 API handlers (`mood-checkin`, `daily-reflection`, `user-profile`, `journal`, `encouragement-next`) |
| iOS auth | `AppCheckTokenProviding.swift` (new), `FirebaseAuthSession.swift` |
| iOS networking | `LiveAPIClient.swift` |
| iOS app setup | `WalkWorthyApp.swift`, `project.pbxproj` |

## Test plan
- [ ] Backend builds: `cd functions && npm run build`
- [ ] iOS builds in Xcode with no errors
- [ ] Debug mode: App Check debug token appears in Xcode console
- [ ] Mood check-in succeeds with valid App Check token
- [ ] `curl` without `X-Firebase-AppCheck` header returns 401
- [ ] `curl` with fake App Check token returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)