### PR TITLE
fix: add missing AppAttestProviderFactory implementation

### DIFF
--- a/WalkWorthy/WalkWorthy/App/WalkWorthyApp.swift
+++ b/WalkWorthy/WalkWorthy/App/WalkWorthyApp.swift
@@ -89,3 +89,12 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         return true
     }
 }
+
+/// Custom App Check provider factory that uses Apple's App Attest service.
+/// Firebase doesn't ship a built-in App Attest factory, so we implement
+/// `AppCheckProviderFactory` ourselves and return an `AppAttestProvider`.
+final class AppAttestProviderFactory: NSObject, AppCheckProviderFactory {
+    func createProvider(with app: FirebaseApp) -> AppCheckProvider? {
+        return AppAttestProvider(app: app)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the release build failure after PR #63. The Firebase iOS SDK provides `AppAttestProvider` but does not ship a factory class for it — only `AppCheckDebugProviderFactory` is built in. The release-build call to `AppAttestProviderFactory()` failed to compile with:

> Cannot find 'AppAttestProviderFactory' in scope

This PR adds a small custom factory conforming to `AppCheckProviderFactory` that returns an `AppAttestProvider`, matching the pattern Firebase recommends for iOS 14+ App Attest integration.

## Change
A 7-line addition to `WalkWorthyApp.swift`:

```swift
final class AppAttestProviderFactory: NSObject, AppCheckProviderFactory {
    func createProvider(with app: FirebaseApp) -> AppCheckProvider? {
        return AppAttestProvider(app: app)
    }
}
```

## Test plan
- [ ] `Build Archive` succeeds in Xcode Cloud / local archive
- [ ] Debug build still works (uses `AppCheckDebugProviderFactory`)
- [ ] Release build uses App Attest

🤖 Generated with [Claude Code](https://claude.com/claude-code)