### PR TITLE
chore: force functions redeploy after build failure

### DIFF
--- a/functions/src/shared/rate-limiter.ts
+++ b/functions/src/shared/rate-limiter.ts
@@ -19,6 +19,8 @@ export interface DailyBudgetResult {
 
 export type RateLimitScope = 'user' | 'ip' | 'dailyBudget';
 
+export const RATE_LIMIT_SCHEMA_VERSION = 1 as const;
+
 export interface RateLimitErrorResponse {
   error: string;
   code: 'RATE_LIMITED';


### PR DESCRIPTION
## Summary
The previous rate-limit deploy ([PR #65](https://github.com/WalkWorthyApp/WalkWorthy/pull/65)) uploaded source bytes but hit a Cloud Build failure (compute SA was missing `roles/cloudbuild.builds.builder`). After the role was granted, subsequent deploys reported "No changes detected" and skipped the build because the source hash was already on record — leaving the running functions built from the pre-rate-limit code.

Adds a no-op schema-version constant to force a hash change and trigger an actual rebuild.

## Test plan
- [ ] CI deploy runs and does NOT show "Skipped (No changes detected)" for functions
- [ ] Post-deploy: trigger a 429 on mood check-in, verify iOS sees `scope: user` (not `unknown`) in console

## Related
[PR #65](https://github.com/WalkWorthyApp/WalkWorthy/pull/65)