### PR TITLE
fix: scope-aware title and text wrapping in mood error overlay

### DIFF
--- a/WalkWorthy/WalkWorthy/Networking/APIError.swift
+++ b/WalkWorthy/WalkWorthy/Networking/APIError.swift
@@ -49,6 +49,15 @@ enum APIError: LocalizedError {
         }
     }
 
+    var errorTitle: String? {
+        switch self {
+        case .rateLimited:
+            return "Usage limit reached"
+        default:
+            return nil
+        }
+    }
+
     private func rateLimitedDescription(retryAfterSeconds: Int?, scope: RateLimitScope) -> String {
         let minutesText: String? = retryAfterSeconds.map { seconds in
             let minutes = Int(ceil(Double(seconds) / 60.0))

--- a/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 
 struct CinematicTransitionView: View {
     let response: MoodCheckInResponse?
+    let errorTitle: String?
     let errorMessage: String?
     let onDone: () -> Void
     let onRetry: () -> Void   // resets to .followUp in MoodCheckInView
@@ -138,29 +139,31 @@ struct CinematicTransitionView: View {
                     .font(.system(size: scaled(44)))
                     .foregroundColor(.orange)
 
-                Text("Something went wrong")
+                Text(errorTitle ?? "Something went wrong")
                     .font(Font.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
                     .foregroundColor(.primary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Text(message)
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, scaled(24))
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Button("Try Again", action: onRetry)
                     .buttonStyle(.bordered)
             }
             .padding(scaled(28))
+            .frame(maxWidth: geo.size.width - scaled(48))
             .background(
                 RoundedRectangle(cornerRadius: scaled(20))
                     .fill(Color.white.opacity(0.92))
             )
-            .padding(.horizontal, scaled(24))
 
             Spacer()
         }
-        .frame(height: geo.size.height * 0.80)
+        .frame(width: geo.size.width, height: geo.size.height * 0.80)
     }
 
     // MARK: - Animation Sequence
@@ -215,6 +218,7 @@ struct CinematicTransitionView: View {
             expiresAt: "",
             isExisting: false
         ),
+        errorTitle: nil,
         errorMessage: nil,
         onDone: {},
         onRetry: {}
@@ -224,7 +228,18 @@ struct CinematicTransitionView: View {
 #Preview("Cinematic - Waiting") {
     CinematicTransitionView(
         response: nil,
+        errorTitle: nil,
         errorMessage: nil,
+        onDone: {},
+        onRetry: {}
+    )
+}
+
+#Preview("Cinematic - Rate Limited") {
+    CinematicTransitionView(
+        response: nil,
+        errorTitle: "Usage limit reached",
+        errorMessage: "You've reached the usage limit for this feature. Try again in ~60 minutes.",
         onDone: {},
         onRetry: {}
     )

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodCheckInView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodCheckInView.swift
@@ -33,6 +33,7 @@ struct MoodCheckInView: View {
     // MARK: - Submission
 
     @State private var submissionResult: MoodCheckInResponse?
+    @State private var errorTitle: String?
     @State private var errorMessage: String?
     @State private var submissionTask: Task<Void, Never>?
 
@@ -89,9 +90,11 @@ struct MoodCheckInView: View {
         case .cinematic:
             CinematicTransitionView(
                 response: submissionResult,
+                errorTitle: errorTitle,
                 errorMessage: errorMessage,
                 onDone: onComplete,
                 onRetry: {
+                    errorTitle = nil
                     errorMessage = nil
                     submissionResult = nil
                     step = .followUp
@@ -139,8 +142,10 @@ struct MoodCheckInView: View {
                 // View was dismissed during submission — no-op
             } catch {
                 await MainActor.run {
+                    let apiError = error as? APIError
+                    errorTitle = apiError?.errorTitle
                     #if DEBUG
-                    if let apiError = error as? APIError {
+                    if let apiError {
                         switch apiError {
                         case .server(let code, let msg):
                             errorMessage = "Server error \(code): \(msg ?? "no message")"
@@ -153,7 +158,7 @@ struct MoodCheckInView: View {
                         errorMessage = error.localizedDescription
                     }
                     #else
-                    errorMessage = (error as? APIError)?.errorDescription ?? error.localizedDescription
+                    errorMessage = apiError?.errorDescription ?? error.localizedDescription
                     #endif
                 }
             }


### PR DESCRIPTION
## Summary
- `APIError` gains an `errorTitle` so rate-limited errors display as **"Usage limit reached"** instead of the generic **"Something went wrong"**
- Error card in `CinematicTransitionView` now has an explicit max width (`geo.size.width - 48`) so long messages wrap inside the card rather than extending past the screen edges
- `MoodCheckInView` threads `errorTitle` through the submission + retry paths

## Before
Title: *"Something went wrong"* (hardcoded)
Body (clipped at both edges): *"ached the usage limit for this feature. Try again in ~60"*

## After
Title: *"Usage limit reached"*
Body (wrapped inside card): *"You've reached the usage limit for this feature. Try again in ~60 minutes."*

## Test plan
- [ ] Trigger a mood check-in rate limit → confirm new title + wrapped body
- [ ] Trigger a regular 5xx → confirm title still falls back to "Something went wrong"
- [ ] Trigger a daily-budget 429 → confirm title + appropriate dailyBudget body copy

## Notes
- Non-rate-limit errors keep the "Something went wrong" title via the nil fallback on `errorTitle`
- Only touches mood check-in flow; other views (daily reflection, etc.) use their own alerts