### PR TITLE
fix: center error overlay card vertically on screen

### DIFF
--- a/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
@@ -163,7 +163,7 @@ struct CinematicTransitionView: View {
 
             Spacer()
         }
-        .frame(width: geo.size.width, height: geo.size.height * 0.80)
+        .frame(width: geo.size.width, height: geo.size.height)
     }
 
     // MARK: - Animation Sequence


### PR DESCRIPTION
## Summary
- Expands the error overlay frame from 80% to full screen height so the two `Spacer` views split evenly, centering the rate-limit card vertically over the hillscape

## Test plan
- [ ] Trigger a 429 (spam check-ins past the hourly limit)
- [ ] Confirm the "Usage limit reached" card appears centered on the cinematic background

🤖 Generated with [Claude Code](https://claude.com/claude-code)