### PR TITLE
Force dark mode app-wide

### DIFF
--- a/WalkWorthy/WalkWorthy/App/WalkWorthyApp.swift
+++ b/WalkWorthy/WalkWorthy/App/WalkWorthyApp.swift
@@ -69,6 +69,7 @@ struct WalkWorthyApp: App {
             RootView()
                 .environmentObject(appState)
                 .modelContainer(container)
+                .preferredColorScheme(.dark)
                 .task {
                     await NotificationScheduler.shared.requestAuthorizationIfNeeded()
                     await appState.startObservingAuthState()

--- a/WalkWorthy/WalkWorthy/Assets.xcassets/AppBackground.colorset/Contents.json
+++ b/WalkWorthy/WalkWorthy/Assets.xcassets/AppBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.957",
+          "green" : "0.929",
+          "red" : "0.910"
         }
       },
       "idiom" : "universal"

--- a/WalkWorthy/WalkWorthy/Assets.xcassets/RecessedBackground.colorset/Contents.json
+++ b/WalkWorthy/WalkWorthy/Assets.xcassets/RecessedBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.988",
-          "green" : "0.973",
-          "red" : "0.961"
+          "blue" : "0.902",
+          "green" : "0.878",
+          "red" : "0.855"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.200",
-          "green" : "0.137",
-          "red" : "0.102"
+          "blue" : "0.149",
+          "green" : "0.102",
+          "red" : "0.075"
         }
       },
       "idiom" : "universal"

--- a/WalkWorthy/WalkWorthy/UI/Components/DynamicBackgroundView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Components/DynamicBackgroundView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct DynamicBackgroundView: View {
     private let timeOfDay = TimeOfDay.current
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -24,14 +25,31 @@ struct DynamicBackgroundView: View {
                 .clipped()
                 .overlay(
                     LinearGradient(
-                        colors: [.clear, Color("AppBackground")],
-                        startPoint: UnitPoint(x: 0.5, y: 0.25), // fade begins 25% down the image
+                        stops: gradientStops,
+                        startPoint: .top,
                         endPoint: .bottom
                     )
                 )
                 .ignoresSafeArea(edges: .top)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    private var gradientStops: [Gradient.Stop] {
+        let appBg = Color("AppBackground")
+        if colorScheme == .dark {
+            return [
+                .init(color: .clear, location: 0.10),
+                .init(color: appBg.opacity(0.4), location: 0.55),
+                .init(color: appBg, location: 1.0)
+            ]
+        } else {
+            return [
+                .init(color: .clear, location: 0.10),
+                .init(color: appBg.opacity(0.2), location: 0.65),
+                .init(color: appBg, location: 1.0)
+            ]
+        }
     }
 }
 

--- a/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
@@ -171,7 +171,7 @@ struct HomeView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: scaled(20), style: .continuous)
-                .fill(.ultraThinMaterial)
+                .fill(Color("RecessedBackground"))
         )
     }
 


### PR DESCRIPTION
## Summary
- Force dark mode via `.preferredColorScheme(.dark)` at the app root so the app always renders in dark regardless of the user's system setting
- Swap `.ultraThinMaterial` on Today's Check-ins for a dedicated `RecessedBackground` color asset — cleaner, more deliberate recessed look
- Soften hero-to-body fade in `DynamicBackgroundView` with a three-stop gradient for a more graceful landing
- Light-mode color variants kept in place as inactive fallbacks (easy revert if we revisit light mode later)

## Test plan
- [ ] Build and run in Xcode; confirm Home, Journal, and Mood check-in pages all render dark regardless of the iOS simulator's appearance setting (toggle Environment Overrides → Appearance to Light and verify the app stays dark)
- [ ] Home: Today's Check-ins container reads as a deliberate darker well, not translucent Material
- [ ] Home / Journal / Mood: hero-to-body fade is smooth with no visible edge
- [ ] No regressions on existing dark-mode pages (Mood slider, history, response views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)