### PR TITLE
feat: time-of-day color palette + glass check-in button

### DIFF
--- a/WalkWorthy/WalkWorthy/Helpers/TimeOfDayTheme.swift
+++ b/WalkWorthy/WalkWorthy/Helpers/TimeOfDayTheme.swift
@@ -1,0 +1,91 @@
+//
+//  TimeOfDayTheme.swift
+//  WalkWorthy
+//
+//  Surface colors (backdrop / card / recessed) keyed to time of day.
+//  Night keeps the ColorSet assets byte-for-byte; morning and midday
+//  shift hue to match the sunrise and meadow hero images.
+//
+
+import SwiftUI
+
+struct TimeOfDayTheme {
+    let timeOfDay: TimeOfDay
+
+    static var current: TimeOfDayTheme {
+        TimeOfDayTheme(timeOfDay: .current)
+    }
+
+    // Full-screen backdrop. Gradient for morning/midday, solid-equivalent for night.
+    var backdrop: LinearGradient {
+        switch timeOfDay {
+        case .morning:
+            // Warm-orange glow near the top (behind + just below the sunrise hero),
+            // blending into a dusky baby-blue base.
+            return LinearGradient(
+                stops: [
+                    .init(color: Self.morningWarm, location: 0.00),
+                    .init(color: Self.morningWarm, location: 0.35),
+                    .init(color: Self.morningBlue, location: 0.55),
+                    .init(color: Self.morningBlue, location: 1.00)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        case .midday:
+            return LinearGradient(
+                colors: [Self.middayGreenTop, Self.middayGreenBottom],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        case .night:
+            let navy = Color("AppBackground")
+            return LinearGradient(colors: [navy, navy], startPoint: .top, endPoint: .bottom)
+        }
+    }
+
+    // Color the hero image's bottom edge fades into, so the hero → backdrop
+    // transition reads as a single continuous surface.
+    var heroFadeTarget: Color {
+        switch timeOfDay {
+        case .morning: return Self.morningWarm
+        case .midday:  return Self.middayGreenTop
+        case .night:   return Color("AppBackground")
+        }
+    }
+
+    var card: Color {
+        switch timeOfDay {
+        case .morning: return Self.morningCard
+        case .midday:  return Self.middayCard
+        case .night:   return Color("CardBackground")
+        }
+    }
+
+    var recessed: Color {
+        switch timeOfDay {
+        case .morning: return Self.morningRecessed
+        case .midday:  return Self.middayRecessed
+        case .night:   return Color("RecessedBackground")
+        }
+    }
+
+    // MARK: - Palette (sRGB, tuned for dark-mode legibility)
+
+    // Morning
+    private static let morningWarm     = Color(red: 0.353, green: 0.239, blue: 0.169) // #5A3D2B (warm sunrise)
+    private static let morningBlue     = Color(red: 0.145, green: 0.235, blue: 0.353) // #253C5A (darker dusky base)
+    private static let morningCard     = Color(red: 0.271, green: 0.408, blue: 0.537) // #456889 (lighter baby blue)
+    private static let morningRecessed = Color(red: 0.196, green: 0.314, blue: 0.459) // #325075
+
+    // Midday
+    private static let middayGreenTop    = Color(red: 0.086, green: 0.153, blue: 0.125) // #162720
+    private static let middayGreenBottom = Color(red: 0.059, green: 0.118, blue: 0.090) // #0F1E17
+    private static let middayCard        = Color(red: 0.106, green: 0.176, blue: 0.141) // #1B2D24
+    private static let middayRecessed    = Color(red: 0.063, green: 0.114, blue: 0.086) // #101D16
+}
+
+extension Color {
+    static var wwCardBackground: Color { TimeOfDayTheme.current.card }
+    static var wwRecessedBackground: Color { TimeOfDayTheme.current.recessed }
+}

--- a/WalkWorthy/WalkWorthy/UI/Components/DynamicBackgroundView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Components/DynamicBackgroundView.swift
@@ -3,22 +3,21 @@
 //  WalkWorthy
 //
 //  Full-screen background: time-of-day hero image pinned to the top,
-//  fading into AppBackground below. Drop this as the bottom layer
-//  of any screen's ZStack.
+//  fading into the time-of-day backdrop gradient below. Drop this as
+//  the bottom layer of any screen's ZStack.
 //
 
 import SwiftUI
 
 struct DynamicBackgroundView: View {
-    private let timeOfDay = TimeOfDay.current
-    @Environment(\.colorScheme) private var colorScheme
+    private let theme = TimeOfDayTheme.current
 
     var body: some View {
         ZStack(alignment: .top) {
-            Color("AppBackground")
+            theme.backdrop
                 .ignoresSafeArea()
 
-            Image(timeOfDay.imageName)
+            Image(theme.timeOfDay.imageName)
                 .resizable()
                 .scaledToFill()
                 .frame(height: scaled(280))
@@ -36,20 +35,12 @@ struct DynamicBackgroundView: View {
     }
 
     private var gradientStops: [Gradient.Stop] {
-        let appBg = Color("AppBackground")
-        if colorScheme == .dark {
-            return [
-                .init(color: .clear, location: 0.10),
-                .init(color: appBg.opacity(0.4), location: 0.55),
-                .init(color: appBg, location: 1.0)
-            ]
-        } else {
-            return [
-                .init(color: .clear, location: 0.10),
-                .init(color: appBg.opacity(0.2), location: 0.65),
-                .init(color: appBg, location: 1.0)
-            ]
-        }
+        let fade = theme.heroFadeTarget
+        return [
+            .init(color: .clear, location: 0.10),
+            .init(color: fade.opacity(0.4), location: 0.55),
+            .init(color: fade, location: 1.0)
+        ]
     }
 }
 

--- a/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
@@ -145,7 +145,11 @@ struct HomeView: View {
             .padding(scaled(20))
             .background(
                 RoundedRectangle(cornerRadius: scaled(20), style: .continuous)
-                    .fill(Color(.systemBackground))
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: scaled(20), style: .continuous)
+                            .fill(Color.black.opacity(0.30))
+                    )
                     .shadow(color: type.color.opacity(0.15), radius: scaled(10), y: scaled(5))
             )
             .overlay(
@@ -171,7 +175,7 @@ struct HomeView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: scaled(20), style: .continuous)
-                .fill(Color("RecessedBackground"))
+                .fill(Color.wwRecessedBackground)
         )
     }
 

--- a/WalkWorthy/WalkWorthy/UI/Journal/JournalListView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/JournalListView.swift
@@ -120,7 +120,7 @@ struct JournalListView: View {
         NavigationLink(destination: JournalEditorView(mode: .existing(entry))) {
             JournalRow(entry: entry, now: Date())
         }
-        .listRowBackground(Color("CardBackground"))
+        .listRowBackground(Color.wwCardBackground)
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
             Button {
                 appState.togglePin(entry)

--- a/WalkWorthy/WalkWorthy/UI/Journal/MoodSummaryCard.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/MoodSummaryCard.swift
@@ -52,7 +52,7 @@ struct MoodSummaryCard: View {
         .padding(scaled(12))
         .background(
             RoundedRectangle(cornerRadius: scaled(20), style: .continuous)
-                .fill(Color("CardBackground"))
+                .fill(Color.wwCardBackground)
         )
     }
 

--- a/WalkWorthy/WalkWorthy/UI/Mood/DailyReflectionCard.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/DailyReflectionCard.swift
@@ -40,7 +40,7 @@ struct DailyReflectionCard: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: scaled(16)).fill(Color("CardBackground")))
+        .background(RoundedRectangle(cornerRadius: scaled(16)).fill(Color.wwCardBackground))
         .animation(.easeInOut(duration: 0.4), value: reflection != nil)
     }
 }

--- a/WalkWorthy/WalkWorthy/UI/Mood/DailyVerseCard.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/DailyVerseCard.swift
@@ -67,6 +67,6 @@ struct DailyVerseCard: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: scaled(16)).fill(Color("CardBackground")))
+        .background(RoundedRectangle(cornerRadius: scaled(16)).fill(Color.wwCardBackground))
     }
 }

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodHistoryView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodHistoryView.swift
@@ -326,7 +326,7 @@ struct MoodHistoryView: View {
         .padding(scaled(20))
         .background(
             RoundedRectangle(cornerRadius: scaled(20))
-                .fill(Color("CardBackground"))
+                .fill(Color.wwCardBackground)
                 .shadow(color: .black.opacity(0.06), radius: scaled(12), x: 0, y: scaled(4))
         )
         .overlay(
@@ -530,7 +530,7 @@ struct MoodHistoryView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: scaled(20), style: .continuous)
-                .fill(Color("CardBackground"))
+                .fill(Color.wwCardBackground)
                 .shadow(color: .black.opacity(0.05), radius: scaled(10), y: scaled(5))
         )
     }

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodResponseView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodResponseView.swift
@@ -94,7 +94,7 @@ struct MoodResponseContent: View {
                     .padding(scaled(12))
                     .background(
                         RoundedRectangle(cornerRadius: scaled(16))
-                            .fill(Color("CardBackground"))
+                            .fill(Color.wwCardBackground)
                     )
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -145,7 +145,7 @@ struct MoodResponseContent: View {
         .background(
             ZStack {
                 RoundedRectangle(cornerRadius: scaled(20))
-                    .fill(Color("CardBackground"))
+                    .fill(Color.wwCardBackground)
 
                 RoundedRectangle(cornerRadius: scaled(20))
                     .fill(

--- a/WalkWorthy/WalkWorthy/UI/Mood/SentimentChartView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/SentimentChartView.swift
@@ -91,6 +91,6 @@ struct SentimentChartView: View {
             }
         }
         .padding()
-        .background(RoundedRectangle(cornerRadius: 16).fill(Color("CardBackground")))
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color.wwCardBackground))
     }
 }


### PR DESCRIPTION
## Summary
- Adds `TimeOfDayTheme` (new: `WalkWorthy/Helpers/TimeOfDayTheme.swift`) — per-time backdrop gradient, card color, recessed color, and hero-fade target. Night uses the existing ColorSet assets verbatim; morning gets a baby-blue base with a warm sunrise glow at the top of the gradient; midday gets a forest-green gradient.
- `DynamicBackgroundView` now fills with the theme's gradient and fades the hero image into the theme's top-hue color so the hero → backdrop transition reads as one continuous surface. Drops the dead light-mode branch (app is dark-only).
- Sweeps 10 card/recessed callsites across 7 views from `Color("CardBackground")` / `Color("RecessedBackground")` to `Color.wwCardBackground` / `Color.wwRecessedBackground` so every surface shifts together.
- Swaps the active check-in button's pure-black `.systemBackground` fill for `.ultraThinMaterial` + a 30%-black overlay — a darkened frosted-glass look that blends with the new time-of-day backdrops. Keeps the type-colored stroke and shadow.

## Test plan
- [ ] Launch between 6 PM–4 AM: backdrop + cards render byte-identical to `main` (night path unchanged).
- [ ] Launch between 5–10 AM: warm-orange band at the top, dusky baby-blue below, cards a lighter baby-blue that clearly pops.
- [ ] Launch between 11 AM–5 PM: forest-green gradient top to deep-green bottom, cards a deep forest-green.
- [ ] Hero image on Home / Journal / Mood History fades cleanly into the backdrop (no visible seam at the hero's bottom edge).
- [ ] Active check-in button on Home reads as frosted glass against each time-of-day backdrop — type-colored stroke and shadow still visible.
- [ ] Text legibility (primary + secondary) passes on every new card color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)