### PR TITLE
Personalization end-to-end + Check-in Log deep-dive

### DIFF
--- a/WalkWorthy/WalkWorthy/App/AppState.swift
+++ b/WalkWorthy/WalkWorthy/App/AppState.swift
@@ -408,6 +408,15 @@ final class AppState: ObservableObject {
         return try await apiClient.fetchMoodHistory(days: days, startDate: startDate, endDate: endDate)
     }
 
+    /// Fetch the full-fidelity mood check-in log (with moodSpectrumData + aiResponse)
+    /// for the past `days` days. Powers the Settings → Check-in Log deep-dive.
+    /// Pass `endDate` (YYYY-MM-DD) to page further back in time.
+    func loadMoodLog(days: Int = 14, endDate: String? = nil) async throws -> MoodLogResponse {
+        guard isAuthenticated else { throw MoodError.notAuthenticated }
+
+        return try await apiClient.fetchMoodLogFullHistory(days: days, endDate: endDate)
+    }
+
     func clearMoodState() {
         currentMoodStatus = nil
         latestMoodResponse = nil

--- a/WalkWorthy/WalkWorthy/App/AppState.swift
+++ b/WalkWorthy/WalkWorthy/App/AppState.swift
@@ -175,10 +175,6 @@ final class AppState: ObservableObject {
         syncStoredProfile()
     }
 
-    func scheduleTestNotification() {
-        notificationScheduler.scheduleTestNotification()
-    }
-
     func startObservingAuthState() async {
         guard !isObservingAuth else { return }
         isObservingAuth = true

--- a/WalkWorthy/WalkWorthy/App/AppState.swift
+++ b/WalkWorthy/WalkWorthy/App/AppState.swift
@@ -15,6 +15,11 @@ final class AppState: ObservableObject {
     @Published var selectedTranslation: Translation
     @Published var onboardingCompleted: Bool
     @Published var useProfilePersonalization: Bool
+    /// Mirrors the UserDefaults-backed profile for SwiftUI-observable access
+    /// (HomeView greeting + tone-aware subtitle). Nil before sign-in / after sign-out.
+    @Published private(set) var currentProfile: OnboardingProfile?
+    /// User has dismissed the "add your first name" prompt on Home. Scoped per user.
+    @Published private(set) var nameBackfillDismissed: Bool = false
     @Published private(set) var authenticatedUserSub: String?
     @Published var isAuthenticated: Bool {
         didSet {
@@ -56,12 +61,14 @@ final class AppState: ObservableObject {
         StorageKey.onboardingCompleted,
         StorageKey.useProfilePersonalization,
         StorageKey.translation,
+        StorageKey.profileFirstName,
         StorageKey.profileAge,
         StorageKey.profileMajor,
         StorageKey.profileOccupation,
         StorageKey.profileGender,
         StorageKey.profileHobbies,
         StorageKey.profileOptIn,
+        StorageKey.dismissedNameBackfill,
     ]
 
     init(
@@ -101,9 +108,15 @@ final class AppState: ObservableObject {
     /// as a local cache. This data is protected by iOS Data Protection, which encrypts UserDefaults
     /// when the device is locked. The authoritative copy is synced to Firebase with proper security rules.
     /// Authentication tokens use Keychain storage with kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly.
-    func updateProfile(age: Int?, occupation: String, major: String, gender: Gender, hobbies: Set<String>, optIn: Bool) {
+    func updateProfile(firstName: String, age: Int?, occupation: String, major: String, gender: Gender, hobbies: Set<String>, optIn: Bool) {
+        let trimmedFirstName = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedOccupation = occupation.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedMajor = major.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedFirstName.isEmpty {
+            defaults.removeObject(forKey: storageKey(StorageKey.profileFirstName))
+        } else {
+            defaults.set(trimmedFirstName, forKey: storageKey(StorageKey.profileFirstName))
+        }
         if let age {
             defaults.set(age, forKey: storageKey(StorageKey.profileAge))
         } else {
@@ -115,26 +128,45 @@ final class AppState: ObservableObject {
         defaults.set(Array(hobbies), forKey: storageKey(StorageKey.profileHobbies))
         defaults.set(optIn, forKey: storageKey(StorageKey.profileOptIn))
 
-        syncProfile(age: age, occupation: trimmedOccupation, major: trimmedMajor, gender: gender, hobbies: hobbies, optIn: optIn)
+        // Refresh observable profile so Home greeting updates without a relaunch.
+        currentProfile = OnboardingProfile(
+            firstName: trimmedFirstName,
+            age: age,
+            occupation: trimmedOccupation,
+            major: trimmedMajor,
+            gender: gender,
+            hobbies: hobbies,
+            optIn: optIn
+        )
+
+        syncProfile(firstName: trimmedFirstName, age: age, occupation: trimmedOccupation, major: trimmedMajor, gender: gender, hobbies: hobbies, optIn: optIn)
     }
 
     func loadProfile() -> OnboardingProfile {
         if authenticatedUserSub == nil {
-            return OnboardingProfile(age: nil, occupation: "", major: "", gender: .male, hobbies: [], optIn: true)
+            return OnboardingProfile(firstName: "", age: nil, occupation: "", major: "", gender: .male, hobbies: [], optIn: true)
         }
 
+        let firstName = defaults.string(forKey: storageKey(StorageKey.profileFirstName)) ?? ""
         let age = defaults.value(forKey: storageKey(StorageKey.profileAge)) as? Int
         let occupation = defaults.string(forKey: storageKey(StorageKey.profileOccupation)) ?? ""
         let major = defaults.string(forKey: storageKey(StorageKey.profileMajor)) ?? ""
         let gender = Gender(rawValue: defaults.string(forKey: storageKey(StorageKey.profileGender)) ?? "") ?? .male
         let hobbies = Set(defaults.stringArray(forKey: storageKey(StorageKey.profileHobbies)) ?? [])
         let optIn = defaults.object(forKey: storageKey(StorageKey.profileOptIn)) as? Bool ?? true
-        return OnboardingProfile(age: age, occupation: occupation, major: major, gender: gender, hobbies: hobbies, optIn: optIn)
+        return OnboardingProfile(firstName: firstName, age: age, occupation: occupation, major: major, gender: gender, hobbies: hobbies, optIn: optIn)
     }
 
     func setUseProfilePersonalization(_ isOn: Bool) {
         useProfilePersonalization = isOn
         defaults.set(isOn, forKey: storageKey(StorageKey.useProfilePersonalization))
+    }
+
+    /// Record the user's dismissal of the "add your first name" banner on Home.
+    /// Scoped per-user; persists across app launches.
+    func setNameBackfillDismissed(_ isDismissed: Bool) {
+        nameBackfillDismissed = isDismissed
+        defaults.set(isDismissed, forKey: storageKey(StorageKey.dismissedNameBackfill))
     }
 
     func setTranslation(_ translation: Translation) {
@@ -253,6 +285,8 @@ final class AppState: ObservableObject {
             onboardingCompleted = false
             useProfilePersonalization = true
             selectedTranslation = config.defaultTranslation
+            currentProfile = nil
+            nameBackfillDismissed = false
             return
         }
 
@@ -267,6 +301,10 @@ final class AppState: ObservableObject {
         useProfilePersonalization = defaults.object(forKey: storageKey(StorageKey.useProfilePersonalization)) as? Bool ?? true
 
         selectedTranslation = Translation(rawValue: defaults.string(forKey: storageKey(StorageKey.translation)) ?? "") ?? config.defaultTranslation
+
+        // Hydrate observable profile mirror + banner-dismissed flag for this user
+        currentProfile = hasStoredProfile() ? loadProfile() : nil
+        nameBackfillDismissed = defaults.bool(forKey: storageKey(StorageKey.dismissedNameBackfill))
     }
 
     private func hasStoredProfile() -> Bool {
@@ -274,6 +312,7 @@ final class AppState: ObservableObject {
             return false
         }
 
+        if defaults.object(forKey: storageKey(StorageKey.profileFirstName)) != nil { return true }
         if defaults.object(forKey: storageKey(StorageKey.profileAge)) != nil { return true }
         if defaults.object(forKey: storageKey(StorageKey.profileOccupation)) != nil { return true }
         if defaults.object(forKey: storageKey(StorageKey.profileMajor)) != nil { return true }
@@ -283,9 +322,9 @@ final class AppState: ObservableObject {
         return false
     }
 
-    private func syncProfile(age: Int?, occupation: String, major: String, gender: Gender, hobbies: Set<String>, optIn: Bool) {
+    private func syncProfile(firstName: String, age: Int?, occupation: String, major: String, gender: Gender, hobbies: Set<String>, optIn: Bool) {
         guard isAuthenticated else { return }
-        let profile = OnboardingProfile(age: age, occupation: occupation, major: major, gender: gender, hobbies: hobbies, optIn: optIn)
+        let profile = OnboardingProfile(firstName: firstName, age: age, occupation: occupation, major: major, gender: gender, hobbies: hobbies, optIn: optIn)
         Task {
             await sendProfileUpdate(profile)
         }
@@ -301,6 +340,7 @@ final class AppState: ObservableObject {
 
     private func sendProfileUpdate(_ profile: OnboardingProfile) async {
         guard isAuthenticated else { return }
+        let trimmedFirstName = profile.firstName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedOccupation = profile.occupation.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedMajor = profile.major.trimmingCharacters(in: .whitespacesAndNewlines)
         let hobbies = profile.hobbies.sorted()
@@ -310,6 +350,7 @@ final class AppState: ObservableObject {
 
         let payload = RemoteUserProfileRequest(
             ageRange: ageRangeString(for: profile.age),
+            firstName: trimmedFirstName.isEmpty ? nil : trimmedFirstName,
             occupation: trimmedOccupation.isEmpty ? nil : trimmedOccupation,
             major: trimmedMajor.isEmpty ? nil : trimmedMajor,
             gender: profile.gender.rawValue.lowercased(),
@@ -533,12 +574,14 @@ extension AppState {
         static let onboardingCompleted = "walkworthy.onboardingCompleted"
         static let useProfilePersonalization = "walkworthy.settings.useProfilePersonalization"
         static let translation = "walkworthy.settings.translation"
+        static let profileFirstName = "walkworthy.profile.firstName"
         static let profileAge = "walkworthy.profile.age"
         static let profileMajor = "walkworthy.profile.major"
         static let profileOccupation = "walkworthy.profile.occupation"
         static let profileGender = "walkworthy.profile.gender"
         static let profileHobbies = "walkworthy.profile.hobbies"
         static let profileOptIn = "walkworthy.profile.optIn"
+        static let dismissedNameBackfill = "walkworthy.dismissed.nameBackfill"
         static let lastAuthenticatedUser = "walkworthy.auth.lastUser"
         static let dailyReflectionPrefix = "walkworthy.dailyReflection"
     }

--- a/WalkWorthy/WalkWorthy/App/AppState.swift
+++ b/WalkWorthy/WalkWorthy/App/AppState.swift
@@ -169,12 +169,6 @@ final class AppState: ObservableObject {
         defaults.set(isDismissed, forKey: storageKey(StorageKey.dismissedNameBackfill))
     }
 
-    func setTranslation(_ translation: Translation) {
-        selectedTranslation = translation
-        defaults.set(translation.rawValue, forKey: storageKey(StorageKey.translation))
-        syncStoredProfile()
-    }
-
     func startObservingAuthState() async {
         guard !isObservingAuth else { return }
         isObservingAuth = true
@@ -321,14 +315,6 @@ final class AppState: ObservableObject {
     private func syncProfile(firstName: String, age: Int?, occupation: String, major: String, gender: Gender, hobbies: Set<String>, optIn: Bool) {
         guard isAuthenticated else { return }
         let profile = OnboardingProfile(firstName: firstName, age: age, occupation: occupation, major: major, gender: gender, hobbies: hobbies, optIn: optIn)
-        Task {
-            await sendProfileUpdate(profile)
-        }
-    }
-
-    private func syncStoredProfile() {
-        guard isAuthenticated else { return }
-        let profile = loadProfile()
         Task {
             await sendProfileUpdate(profile)
         }

--- a/WalkWorthy/WalkWorthy/Assets.xcassets/bgMidday.imageset/Contents.json
+++ b/WalkWorthy/WalkWorthy/Assets.xcassets/bgMidday.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "bgMidday.jpg",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/WalkWorthy/WalkWorthy/Assets.xcassets/bgMorning.imageset/Contents.json
+++ b/WalkWorthy/WalkWorthy/Assets.xcassets/bgMorning.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "bgMorning.jpg",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/WalkWorthy/WalkWorthy/Assets.xcassets/bgNight.imageset/Contents.json
+++ b/WalkWorthy/WalkWorthy/Assets.xcassets/bgNight.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "bgNight.jpg",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/WalkWorthy/WalkWorthy/Models/EncouragementModels.swift
+++ b/WalkWorthy/WalkWorthy/Models/EncouragementModels.swift
@@ -20,6 +20,9 @@ protocol EncouragementAPI {
 
 struct RemoteUserProfileRequest: Codable {
     var ageRange: String?
+    /// Optional first name used only for Home-view greeting personalization.
+    /// NOT forwarded to AI agents on the backend.
+    var firstName: String?
     var occupation: String?
     var major: String?
     var gender: String?
@@ -62,6 +65,9 @@ enum Gender: String, CaseIterable, Identifiable {
 }
 
 struct OnboardingProfile {
+    /// Optional first name. Empty/whitespace means not set. Used only for Home
+    /// greeting personalization — never passed to AI agents.
+    var firstName: String
     var age: Int?
     var occupation: String  // For professionals
     var major: String       // For students

--- a/WalkWorthy/WalkWorthy/Models/EncouragementModels.swift
+++ b/WalkWorthy/WalkWorthy/Models/EncouragementModels.swift
@@ -14,6 +14,7 @@ protocol EncouragementAPI {
     func submitMoodCheckIn(_ request: MoodCheckInRequest) async throws -> MoodCheckInResponse
     func fetchMoodStatus() async throws -> MoodStatusResponse
     func fetchMoodHistory(days: Int, startDate: String?, endDate: String?) async throws -> MoodHistoryResponse
+    func fetchMoodLogFullHistory(days: Int, endDate: String?) async throws -> MoodLogResponse
     func fetchDailyReflection() async throws -> DailyReflection
 
 }

--- a/WalkWorthy/WalkWorthy/Models/MoodModels.swift
+++ b/WalkWorthy/WalkWorthy/Models/MoodModels.swift
@@ -231,6 +231,15 @@ struct MoodHistoryResponse: Codable {
     let daysRequested: Int
 }
 
+/// Full-fidelity check-in log response — each entry contains
+/// `moodSpectrumData` (tags, impacts, note) and the full `aiResponse`,
+/// unlike `MoodHistoryResponse` which only carries per-day summaries.
+/// Powers the Settings → Check-in Log deep-dive view.
+struct MoodLogResponse: Codable {
+    let checkIns: [MoodCheckIn]
+    let daysRequested: Int
+}
+
 // MARK: - Daily Reflection
 
 struct DailyReflection: Codable, Equatable {

--- a/WalkWorthy/WalkWorthy/Networking/LiveAPIClient.swift
+++ b/WalkWorthy/WalkWorthy/Networking/LiveAPIClient.swift
@@ -118,6 +118,21 @@ final class LiveAPIClient: EncouragementAPI {
         return try await send(request, decode: MoodHistoryResponse.self)
     }
 
+    func fetchMoodLogFullHistory(days: Int, endDate: String?) async throws -> MoodLogResponse {
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "fullHistory", value: String(days))
+        ]
+        if let endDate {
+            queryItems.append(URLQueryItem(name: "endDate", value: endDate))
+        }
+        let request = try await makeRequest(
+            path: "moodCheckIn",
+            method: "GET",
+            queryItems: queryItems
+        )
+        return try await send(request, decode: MoodLogResponse.self)
+    }
+
     private static func logicalDate() -> Date {
         let hour = Calendar.current.component(.hour, from: Date())
         guard hour < 3 else { return Date() }

--- a/WalkWorthy/WalkWorthy/Notifications/NotificationScheduler.swift
+++ b/WalkWorthy/WalkWorthy/Notifications/NotificationScheduler.swift
@@ -42,31 +42,6 @@ final class NotificationScheduler: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
-    func scheduleTestNotification(in seconds: TimeInterval = 10) {
-        Task {
-            if !(await isAuthorized) {
-                await requestAuthorizationIfNeeded()
-            }
-            guard await isAuthorized else { return }
-            let content = UNMutableNotificationContent()
-            content.title = "WalkWorthy"
-            content.body = "This is your test encouragement notification."
-            content.sound = .default
-            content.categoryIdentifier = NotificationCategory.encouragement.rawValue
-
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, seconds), repeats: false)
-            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
-
-            do {
-                try await center.add(request)
-            } catch {
-                #if DEBUG
-                print("[NotificationScheduler] Failed to schedule test notification: \(error)")
-                #endif
-            }
-        }
-    }
-
     private var isAuthorized: Bool {
         get async {
             let settings = await center.notificationSettings()

--- a/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
@@ -11,12 +11,23 @@ struct HomeView: View {
     @Binding var selectedTab: Int
     @EnvironmentObject private var appState: AppState
     @State private var activeCheckInType: CheckInType?
+    @State private var showNameSheet: Bool = false
 
     var body: some View {
         ZStack {
             DynamicBackgroundView()
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: scaled(24)) {
+                    // Soft prompt for users who never entered a first name.
+                    // Auto-hides once the name is filled in or the user dismisses.
+                    if shouldShowNameBackfillBanner {
+                        NameBackfillBanner(
+                            onAdd: { showNameSheet = true },
+                            onDismiss: { appState.setNameBackfillDismissed(true) }
+                        )
+                        .transition(.opacity)
+                    }
+
                     // Greeting header
                     greetingHeader
 
@@ -66,6 +77,22 @@ struct HomeView: View {
             }
             .presentationDetents([.large])
         }
+        .sheet(isPresented: $showNameSheet) {
+            // Reuses the existing OnboardingForm. In "edit existing profile"
+            // mode it dismisses itself on save, closing this sheet naturally.
+            OnboardingForm()
+        }
+    }
+
+    // MARK: - Name backfill banner visibility
+
+    private var shouldShowNameBackfillBanner: Bool {
+        guard appState.isAuthenticated else { return false }
+        guard appState.authenticatedUserSub != nil else { return false }
+        guard !appState.nameBackfillDismissed else { return false }
+        let name = (appState.currentProfile?.firstName ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty
     }
 
     private var greetingHeader: some View {
@@ -84,28 +111,71 @@ struct HomeView: View {
 
     private var timeBasedGreeting: String {
         let hour = Calendar.current.component(.hour, from: Date())
+        let base: String
         switch hour {
         case 3..<12:
-            return "Good morning"
+            base = "Good morning"
         case 12..<17:
-            return "Good afternoon"
+            base = "Good afternoon"
         case 17..<22:
-            return "Good evening"
+            base = "Good evening"
         default:
-            return "Good night"
+            base = "Good night"
         }
+        let name = (appState.currentProfile?.firstName ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? base : "\(base), \(name)"
+    }
+
+    /// Tone categories for the greeting subtitle, derived from profile identity markers.
+    private enum SubtitleTone {
+        case student
+        case professional
+        case none
+    }
+
+    /// If the user has a major, treat them as a student; else if they have an occupation,
+    /// treat them as a professional; else fall back to the original generic tone.
+    private var subtitleTone: SubtitleTone {
+        guard let profile = appState.currentProfile else { return .none }
+        let hasMajor = !profile.major.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasOccupation = !profile.occupation.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if hasMajor { return .student }
+        if hasOccupation { return .professional }
+        return .none
     }
 
     private var motivationalSubtitle: String {
         let hour = Calendar.current.component(.hour, from: Date())
-        switch hour {
-        case 3..<12:
+        switch (subtitleTone, hour) {
+        // Student tone
+        case (.student, 3..<12):
+            return "A quiet moment before the day begins."
+        case (.student, 12..<17):
+            return "A breath between classes."
+        case (.student, 17..<22):
+            return "How did your day of learning feel?"
+        case (.student, _):
+            return "Rest up — tomorrow holds more to learn."
+
+        // Professional tone
+        case (.professional, 3..<12):
+            return "Catch your breath before the day starts."
+        case (.professional, 12..<17):
+            return "A breath between meetings."
+        case (.professional, 17..<22):
+            return "How did work feel today?"
+        case (.professional, _):
+            return "Rest well. Tomorrow is its own day."
+
+        // Default (no identity markers yet)
+        case (.none, 3..<12):
             return "Let's start the day with intention."
-        case 12..<17:
+        case (.none, 12..<17):
             return "Pause and check in with yourself."
-        case 17..<22:
+        case (.none, 17..<22):
             return "Reflect on how today went."
-        default:
+        case (.none, _):
             return "Rest well and prepare for tomorrow."
         }
     }
@@ -238,5 +308,51 @@ private struct GlassButtonStyle: ButtonStyle {
             .foregroundStyle(.primary)
             .scaleEffect(configuration.isPressed ? 0.97 : 1)
             .animation(.spring(response: 0.25, dampingFraction: 0.8), value: configuration.isPressed)
+    }
+}
+
+/// Soft, dismissible prompt shown on Home for users who haven't set a first name.
+/// Tapping the card opens the full profile editor; tapping the × dismisses persistently.
+private struct NameBackfillBanner: View {
+    let onAdd: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: scaled(14)) {
+            Image(systemName: "hand.wave.fill")
+                .font(.system(size: scaled(22)))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: scaled(44), height: scaled(44))
+                .background(Circle().fill(Color.accentColor.opacity(0.15)))
+
+            VStack(alignment: .leading, spacing: scaled(2)) {
+                Text("Add your name")
+                    .font(.newsreaderSemiBoldItalic(fixedSize: scaled(17)))
+                    .foregroundColor(.primary)
+                Text("Get a personal greeting on Home.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: scaled(13), weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .frame(width: scaled(30), height: scaled(30))
+                    .background(Circle().fill(Color.secondary.opacity(0.15)))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+        }
+        .padding(scaled(16))
+        .background(
+            RoundedRectangle(cornerRadius: scaled(20), style: .continuous)
+                .fill(Color.wwRecessedBackground)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onAdd)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Double-tap to add your first name.")
     }
 }

--- a/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
@@ -141,13 +141,13 @@ struct CinematicTransitionView: View {
 
                 Text(errorTitle ?? "Something went wrong")
                     .font(Font.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
-                    .foregroundColor(.primary)
+                    .foregroundColor(.black)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(message)
                     .font(.body)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(.black.opacity(0.7))
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
 

--- a/WalkWorthy/WalkWorthy/UI/Mood/DailyVerseCard.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/DailyVerseCard.swift
@@ -61,9 +61,14 @@ struct DailyVerseCard: View {
                 .lineSpacing(scaled(4))
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text("— \(todaysVerse.ref)")
-                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(13)))
-                .foregroundStyle(.secondary)
+            HStack(spacing: scaled(6)) {
+                Text("— \(todaysVerse.ref)")
+                    .font(.newsreaderSemiBoldItalic(fixedSize: scaled(13)))
+                    .foregroundStyle(.secondary)
+                Text("·  ESV")
+                    .font(.newsreaderSemiBoldItalic(fixedSize: scaled(12)))
+                    .foregroundStyle(.secondary.opacity(0.7))
+            }
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodLogView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodLogView.swift
@@ -1,0 +1,712 @@
+//
+//  MoodLogView.swift
+//  WalkWorthy
+//
+//  Settings → Check-in log deep-dive view. A day-grouped feed where each
+//  check-in shows its mood data, emotion tags, impact categories, note,
+//  and AI encouragement — with any linked journal entries nested beneath
+//  it and standalone journal entries (no linkedCheckInId) shown as their
+//  own cards under the same day header.
+//
+//  Distinct from the History tab (MoodHistoryView, which is aggregate /
+//  chart-oriented) and the Journal tab (JournalListView, which is writing-
+//  oriented). This screen is the "everything about my mood + journal in
+//  one place" power-user view.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: - Shared formatters
+
+private let moodLogISODateFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "yyyy-MM-dd"
+    f.locale = Locale(identifier: "en_US_POSIX")
+    return f
+}()
+
+private let moodLogDayHeaderFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "EEEE, MMM d"
+    f.locale = Locale.current
+    return f
+}()
+
+private let moodLogTimeFormatter: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+}()
+
+private let moodLogTimeFormatterFallback: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime]
+    return f
+}()
+
+private let moodLogTimeDisplayFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "h:mm a"
+    f.locale = Locale.current
+    return f
+}()
+
+// MARK: - Grouping model
+
+private enum MoodLogEntry: Identifiable {
+    case checkIn(MoodCheckIn, linkedJournals: [JournalEntry])
+    case standaloneJournal(JournalEntry)
+
+    var id: String {
+        switch self {
+        case .checkIn(let ci, _): return "ci-\(ci.id)"
+        case .standaloneJournal(let j): return "j-\(j.id)"
+        }
+    }
+}
+
+private struct MoodLogDay: Identifiable {
+    let date: String               // YYYY-MM-DD
+    var entries: [MoodLogEntry]
+    var id: String { date }
+}
+
+// MARK: - Main view
+
+struct MoodLogView: View {
+    @EnvironmentObject private var appState: AppState
+    @Query(sort: \JournalEntry.createdAt, order: .reverse)
+    private var allJournalEntries: [JournalEntry]
+
+    @State private var checkIns: [MoodCheckIn] = []
+    @State private var isLoading: Bool = false
+    @State private var hasMore: Bool = true
+    @State private var oldestLoadedDate: String? = nil
+    @State private var errorMessage: String? = nil
+
+    private static let pageSize: Int = 14
+
+    var body: some View {
+        ZStack {
+            TimeOfDayTheme.current.backdrop
+                .ignoresSafeArea()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: scaled(20)) {
+                    intro
+                    ForEach(logDays) { day in
+                        MoodLogDaySection(day: day)
+                    }
+                    footer
+                }
+                .padding(.horizontal, scaled(20))
+                .padding(.vertical, scaled(24))
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .navigationTitle("Check-in log")
+        .toolbarTitleDisplayMode(.inline)
+        .task {
+            if checkIns.isEmpty && !isLoading {
+                await loadFirstPage()
+            }
+        }
+        .refreshable { await loadFirstPage() }
+    }
+
+    // MARK: Subviews
+
+    private var intro: some View {
+        Text("Your check-ins, tags, and journal entries together.")
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .padding(.bottom, scaled(4))
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        if isLoading && checkIns.isEmpty {
+            ProgressView()
+                .frame(maxWidth: .infinity)
+                .padding(.top, scaled(40))
+        } else if checkIns.isEmpty && allJournalEntries.isEmpty {
+            emptyState
+        } else if let errorMessage {
+            VStack(spacing: scaled(10)) {
+                Text(errorMessage)
+                    .font(.subheadline)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                Button("Try again") {
+                    Task { await loadFirstPage() }
+                }
+                .buttonStyle(.bordered)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, scaled(12))
+        } else if hasMore {
+            Button {
+                Task { await loadOlder() }
+            } label: {
+                if isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, scaled(4))
+                } else {
+                    Label("Load older (\(Self.pageSize) more days)", systemImage: "arrow.down.circle")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.bordered)
+            .padding(.top, scaled(8))
+            .disabled(isLoading)
+        } else {
+            Text("That's the beginning of your log.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity)
+                .padding(.top, scaled(12))
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: scaled(12)) {
+            Image(systemName: "square.and.pencil")
+                .font(.system(size: scaled(36)))
+                .foregroundStyle(.secondary)
+            Text("No check-ins yet")
+                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
+            Text("Your log will appear here after your first check-in.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, scaled(60))
+    }
+
+    // MARK: Grouping
+
+    /// Merge loaded check-ins with SwiftData journal entries into day sections.
+    /// Check-ins come first within a day (morning → midday → evening), then
+    /// any standalone journal entries (no linkedCheckInId, or whose link points
+    /// to a check-in outside the loaded window).
+    private var logDays: [MoodLogDay] {
+        let windowStart = oldestLoadedDate ?? Self.dateString(daysAgo: Self.pageSize)
+        let journalsInWindow = allJournalEntries.filter { $0.date >= windowStart }
+        let checkInIds = Set(checkIns.map { $0.id })
+
+        var byDate: [String: MoodLogDay] = [:]
+
+        for checkIn in checkIns {
+            let linked = journalsInWindow.filter { $0.linkedCheckInId == checkIn.id }
+            byDate[checkIn.date, default: MoodLogDay(date: checkIn.date, entries: [])]
+                .entries.append(.checkIn(checkIn, linkedJournals: linked))
+        }
+
+        for journal in journalsInWindow {
+            let isStandalone: Bool = {
+                guard let link = journal.linkedCheckInId else { return true }
+                // Treat as standalone if the linked check-in isn't in the current window
+                return !checkInIds.contains(link)
+            }()
+            if isStandalone {
+                byDate[journal.date, default: MoodLogDay(date: journal.date, entries: [])]
+                    .entries.append(.standaloneJournal(journal))
+            }
+        }
+
+        // Sort entries within each day: check-ins first by type order, then standalones by createdAt desc
+        for date in byDate.keys {
+            byDate[date]?.entries.sort { a, b in
+                switch (a, b) {
+                case (.checkIn(let lhs, _), .checkIn(let rhs, _)):
+                    return Self.typeOrder(lhs.checkInType) < Self.typeOrder(rhs.checkInType)
+                case (.checkIn, .standaloneJournal):
+                    return true
+                case (.standaloneJournal, .checkIn):
+                    return false
+                case (.standaloneJournal(let lhs), .standaloneJournal(let rhs)):
+                    return lhs.createdAt > rhs.createdAt
+                }
+            }
+        }
+
+        // Days: newest first
+        return byDate.keys.sorted(by: >).compactMap { byDate[$0] }
+    }
+
+    private static func typeOrder(_ raw: String) -> Int {
+        switch raw {
+        case "morning": return 0
+        case "midday":  return 1
+        case "evening": return 2
+        default:        return 3
+        }
+    }
+
+    private static func dateString(daysAgo: Int) -> String {
+        let d = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()) ?? Date()
+        return moodLogISODateFormatter.string(from: d)
+    }
+
+    private static func dateByOffsetting(_ dateString: String, days: Int) -> String? {
+        guard let date = moodLogISODateFormatter.date(from: dateString),
+              let shifted = Calendar.current.date(byAdding: .day, value: days, to: date)
+        else { return nil }
+        return moodLogISODateFormatter.string(from: shifted)
+    }
+
+    // MARK: Loading
+
+    private func loadFirstPage() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            let response = try await appState.loadMoodLog(days: Self.pageSize, endDate: nil)
+            checkIns = response.checkIns
+            oldestLoadedDate = Self.dateString(daysAgo: Self.pageSize)
+            // If the backend returned fewer docs than we asked for, assume there may still
+            // be older data in Firestore — only mark hasMore=false when user has paged back
+            // and explicitly gets an empty response.
+            hasMore = true
+        } catch {
+            #if DEBUG
+            print("[MoodLogView] loadFirstPage failed: \(error)")
+            #endif
+            errorMessage = "Couldn't load your check-in log."
+        }
+    }
+
+    private func loadOlder() async {
+        guard let oldest = oldestLoadedDate,
+              let priorEnd = Self.dateByOffsetting(oldest, days: -1)
+        else { return }
+
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let response = try await appState.loadMoodLog(days: Self.pageSize, endDate: priorEnd)
+            if response.checkIns.isEmpty {
+                hasMore = false
+            } else {
+                // Dedup by id in case of overlap
+                let existingIds = Set(checkIns.map { $0.id })
+                let additions = response.checkIns.filter { !existingIds.contains($0.id) }
+                checkIns.append(contentsOf: additions)
+                if let newOldest = Self.dateByOffsetting(oldest, days: -Self.pageSize) {
+                    oldestLoadedDate = newOldest
+                }
+            }
+        } catch {
+            #if DEBUG
+            print("[MoodLogView] loadOlder failed: \(error)")
+            #endif
+            errorMessage = "Couldn't load older entries."
+        }
+    }
+}
+
+// MARK: - Day section
+
+private struct MoodLogDaySection: View {
+    let day: MoodLogDay
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: scaled(12)) {
+            Text(dayHeaderText)
+                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
+                .foregroundStyle(.primary)
+
+            ForEach(day.entries) { entry in
+                switch entry {
+                case .checkIn(let checkIn, let linkedJournals):
+                    MoodLogCheckInCard(checkIn: checkIn, linkedJournals: linkedJournals)
+                case .standaloneJournal(let journal):
+                    MoodLogStandaloneJournalCard(journal: journal)
+                }
+            }
+        }
+    }
+
+    private var dayHeaderText: String {
+        if let d = moodLogISODateFormatter.date(from: day.date) {
+            return moodLogDayHeaderFormatter.string(from: d)
+        }
+        return day.date
+    }
+}
+
+// MARK: - Check-in card
+
+private struct MoodLogCheckInCard: View {
+    let checkIn: MoodCheckIn
+    let linkedJournals: [JournalEntry]
+
+    private var typeEnum: CheckInType? {
+        CheckInType(rawValue: checkIn.checkInType)
+    }
+
+    private var moodLevelEnum: MoodLevel? {
+        guard let raw = checkIn.moodSpectrumData?.moodLevel else { return nil }
+        return MoodLevel(rawValue: raw)
+    }
+
+    private var displayTime: String {
+        let parsed = moodLogTimeFormatter.date(from: checkIn.timestamp)
+            ?? moodLogTimeFormatterFallback.date(from: checkIn.timestamp)
+        guard let date = parsed else { return "" }
+        return moodLogTimeDisplayFormatter.string(from: date)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: scaled(14)) {
+            header
+
+            if let data = checkIn.moodSpectrumData {
+                if !data.emotionTags.isEmpty {
+                    pillRow(title: "Feelings", items: data.emotionTags, style: .emotion)
+                }
+                if !data.impactCategories.isEmpty {
+                    pillRow(title: "Impacting", items: data.impactCategories, style: .impact)
+                }
+                if let note = data.note, !note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    noteBlock(note)
+                }
+            }
+
+            aiResponseBlock
+
+            if !linkedJournals.isEmpty {
+                linkedJournalsBlock
+            }
+        }
+        .padding(scaled(18))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: scaled(18), style: .continuous)
+                .fill(Color.wwCardBackground)
+        )
+        .overlay(alignment: .leading) {
+            // Subtle check-in-type accent stripe on the leading edge.
+            if let type = typeEnum {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(type.color.opacity(0.7))
+                    .frame(width: 3)
+                    .padding(.vertical, scaled(14))
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: scaled(10)) {
+            if let type = typeEnum {
+                Image(systemName: type.iconName)
+                    .font(.system(size: scaled(18), weight: .semibold))
+                    .foregroundStyle(type.color)
+                    .frame(width: scaled(32), height: scaled(32))
+                    .background(Circle().fill(type.color.opacity(0.15)))
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(typeEnum?.displayName ?? checkIn.checkInType.capitalized)
+                    .font(.newsreaderSemiBoldItalic(fixedSize: scaled(17)))
+                    .foregroundStyle(.primary)
+                if !displayTime.isEmpty {
+                    Text(displayTime)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if let moodLevel = moodLevelEnum {
+                moodPill(moodLevel)
+            }
+
+            if let score = checkIn.moodSpectrumData?.moodScore {
+                Text("\(score)/10")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, scaled(8))
+                    .padding(.vertical, scaled(4))
+                    .background(
+                        Capsule().fill(Color.secondary.opacity(0.15))
+                    )
+            }
+        }
+    }
+
+    private func moodPill(_ level: MoodLevel) -> some View {
+        Text(level.displayName)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, scaled(10))
+            .padding(.vertical, scaled(4))
+            .background(
+                Capsule().fill(pillColor(for: level).opacity(0.25))
+            )
+            .overlay(
+                Capsule().stroke(pillColor(for: level).opacity(0.5), lineWidth: 1)
+            )
+    }
+
+    private func pillColor(for level: MoodLevel) -> Color {
+        switch level {
+        case .veryUnpleasant, .unpleasant: return .red
+        case .neutral:                     return .gray
+        case .pleasant, .veryPleasant:     return .green
+        }
+    }
+
+    private enum PillStyle { case emotion, impact }
+
+    private func pillRow(title: String, items: [String], style: PillStyle) -> some View {
+        VStack(alignment: .leading, spacing: scaled(6)) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            FlowLayout(spacing: scaled(6)) {
+                ForEach(items, id: \.self) { item in
+                    Text(item)
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, scaled(10))
+                        .padding(.vertical, scaled(4))
+                        .background(
+                            Capsule().fill(
+                                style == .emotion
+                                    ? Color.accentColor.opacity(0.15)
+                                    : Color.secondary.opacity(0.15)
+                            )
+                        )
+                }
+            }
+        }
+    }
+
+    private func noteBlock(_ note: String) -> some View {
+        HStack(alignment: .top, spacing: scaled(10)) {
+            Image(systemName: "quote.opening")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(note)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(scaled(12))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: scaled(12), style: .continuous)
+                .fill(Color.wwRecessedBackground)
+        )
+    }
+
+    private var aiResponseBlock: some View {
+        VStack(alignment: .leading, spacing: scaled(8)) {
+            HStack(spacing: scaled(6)) {
+                Image(systemName: "sparkles")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("Encouragement")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(checkIn.aiResponse.message)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(checkIn.aiResponse.verseText)
+                .font(.newsreader(fixedSize: scaled(15)))
+                .foregroundStyle(.primary)
+                .lineSpacing(scaled(3))
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("— \(checkIn.aiResponse.verseRef) · \(checkIn.aiResponse.translation)")
+                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(12)))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, scaled(4))
+    }
+
+    private var linkedJournalsBlock: some View {
+        VStack(alignment: .leading, spacing: scaled(8)) {
+            HStack(spacing: scaled(6)) {
+                Image(systemName: "link")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("Journal entries")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(linkedJournals) { journal in
+                NavigationLink {
+                    JournalEditorView(mode: .existing(journal))
+                } label: {
+                    MoodLogJournalRow(journal: journal)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.top, scaled(4))
+    }
+}
+
+// MARK: - Journal rows
+
+private struct MoodLogJournalRow: View {
+    let journal: JournalEntry
+
+    var body: some View {
+        HStack(alignment: .top, spacing: scaled(10)) {
+            if journal.isPinned {
+                Image(systemName: "pin.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .padding(.top, 2)
+            } else {
+                Image(systemName: "book")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 1)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(previewText)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Text(timeString)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.right")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary.opacity(0.6))
+        }
+        .padding(scaled(12))
+        .background(
+            RoundedRectangle(cornerRadius: scaled(12), style: .continuous)
+                .fill(Color.wwRecessedBackground)
+        )
+    }
+
+    private var previewText: String {
+        let trimmed = journal.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "(empty entry)" : trimmed
+    }
+
+    private var timeString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        formatter.locale = Locale.current
+        return formatter.string(from: journal.createdAt)
+    }
+}
+
+private struct MoodLogStandaloneJournalCard: View {
+    let journal: JournalEntry
+
+    var body: some View {
+        NavigationLink {
+            JournalEditorView(mode: .existing(journal))
+        } label: {
+            VStack(alignment: .leading, spacing: scaled(8)) {
+                HStack(spacing: scaled(8)) {
+                    Image(systemName: journal.isPinned ? "pin.fill" : "book.fill")
+                        .font(.caption)
+                        .foregroundStyle(journal.isPinned ? .orange : .secondary)
+                    Text("Journal entry")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(timeString)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(previewText)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(scaled(16))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: scaled(18), style: .continuous)
+                    .fill(Color.wwCardBackground)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var previewText: String {
+        let trimmed = journal.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "(empty entry)" : trimmed
+    }
+
+    private var timeString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        formatter.locale = Locale.current
+        return formatter.string(from: journal.createdAt)
+    }
+}
+
+// MARK: - Simple flow layout for pill rows
+
+/// Minimal wrap-to-next-line layout used for emotion/impact pill rows.
+/// Avoids pulling in a third-party library for a single use case.
+private struct FlowLayout: Layout {
+    let spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var totalHeight: CGFloat = 0
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if rowWidth + size.width + (rowWidth > 0 ? spacing : 0) > maxWidth {
+                totalHeight += rowHeight + (totalHeight > 0 ? spacing : 0)
+                rowWidth = size.width
+                rowHeight = size.height
+            } else {
+                rowWidth += size.width + (rowWidth > 0 ? spacing : 0)
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+        totalHeight += rowHeight
+        return CGSize(width: maxWidth.isFinite ? maxWidth : rowWidth, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x: CGFloat = bounds.minX
+        var y: CGFloat = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
+++ b/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct OnboardingForm: View {
     @EnvironmentObject private var appState: AppState
     @Environment(\.dismiss) private var dismiss
+    @State private var firstName: String = ""
     @State private var ageText: String = ""
     @State private var occupation: String = ""
     @State private var major: String = ""
@@ -24,6 +25,7 @@ struct OnboardingForm: View {
     @FocusState private var focusedField: Field?
 
     enum Field {
+        case firstName
         case age
         case occupation
         case major
@@ -45,6 +47,7 @@ struct OnboardingForm: View {
         ScrollView {
             VStack(alignment: .leading, spacing: scaled(24)) {
                 header
+                firstNameSection
                 ageSection
                 contextSection
                 genderSection
@@ -80,6 +83,29 @@ struct OnboardingForm: View {
                 .font(.largeTitle.bold())
             Text("Help us tailor encouragements to your rhythms. Your information stays private and secure.")
                 .font(.body)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var firstNameSection: some View {
+        VStack(alignment: .leading, spacing: scaled(8)) {
+            HStack(spacing: scaled(6)) {
+                Text("First name")
+                    .font(.headline)
+                Text("(optional)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            TextField("Your first name", text: $firstName)
+                .textContentType(.givenName)
+                .textInputAutocapitalization(.words)
+                .disableAutocorrection(true)
+                .padding()
+                .glassCard()
+                .focused($focusedField, equals: .firstName)
+                .accessibilityLabel("First name (optional)")
+            Text("Used only for your greeting on the Home screen.")
+                .font(.footnote)
                 .foregroundStyle(.secondary)
         }
     }
@@ -256,6 +282,7 @@ struct OnboardingForm: View {
         isEditingExistingProfile = appState.onboardingCompleted
 
         let profile = appState.loadProfile()
+        firstName = profile.firstName
         if let age = profile.age {
             ageText = String(age)
         } else {
@@ -316,11 +343,13 @@ struct OnboardingForm: View {
 
         focusedField = nil
         let age = Int(ageText)
+        let trimmedFirstName = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedOccupation = occupation.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedMajor = major.trimmingCharacters(in: .whitespacesAndNewlines)
+        firstName = trimmedFirstName
         occupation = trimmedOccupation
         major = trimmedMajor
-        appState.updateProfile(age: age, occupation: trimmedOccupation, major: trimmedMajor, gender: gender, hobbies: selectedHobbies, optIn: optIn)
+        appState.updateProfile(firstName: trimmedFirstName, age: age, occupation: trimmedOccupation, major: trimmedMajor, gender: gender, hobbies: selectedHobbies, optIn: optIn)
         appState.markOnboardingComplete()
 
         if isEditingExistingProfile {

--- a/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
+++ b/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
@@ -85,7 +85,7 @@ struct OnboardingForm: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: scaled(12)) {
             Text("Welcome to WalkWorthy")
-                .font(.largeTitle.bold())
+                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(32)))
             Text("Help us tailor encouragements to your rhythms. Your information stays private and secure.")
                 .font(.body)
                 .foregroundStyle(.secondary)
@@ -96,7 +96,7 @@ struct OnboardingForm: View {
         VStack(alignment: .leading, spacing: scaled(8)) {
             HStack(spacing: scaled(6)) {
                 Text("First name")
-                    .font(.headline)
+                    .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
                 Text("(optional)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -118,7 +118,7 @@ struct OnboardingForm: View {
     private var ageSection: some View {
         VStack(alignment: .leading, spacing: scaled(8)) {
             Text("Age")
-                .font(.headline)
+                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
             TextField("18", text: $ageText)
                 .keyboardType(.numberPad)
                 .textContentType(.oneTimeCode)
@@ -138,7 +138,7 @@ struct OnboardingForm: View {
         VStack(alignment: .leading, spacing: scaled(16)) {
             VStack(alignment: .leading, spacing: scaled(8)) {
                 Text("What do you do?")
-                    .font(.headline)
+                    .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
                 Text("Fill in whichever applies to you, or both.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
@@ -181,7 +181,7 @@ struct OnboardingForm: View {
     private var genderSection: some View {
         VStack(alignment: .leading, spacing: scaled(8)) {
             Text("Gender")
-                .font(.headline)
+                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
             Picker("Gender", selection: $gender) {
                 ForEach(Gender.allCases) { option in
                     Text(option.rawValue).tag(option)
@@ -195,7 +195,7 @@ struct OnboardingForm: View {
     private var hobbiesSection: some View {
         VStack(alignment: .leading, spacing: scaled(12)) {
             Text("Hobbies")
-                .font(.headline)
+                .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
             Text("Pick a few that spark joy, or add your own.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -239,7 +239,7 @@ struct OnboardingForm: View {
         Toggle(isOn: $optIn) {
             VStack(alignment: .leading, spacing: scaled(4)) {
                 Text("Receive encouragement nudges")
-                    .font(.headline)
+                    .font(.newsreaderSemiBoldItalic(fixedSize: scaled(20)))
                 Text("We'll keep them gentle and focused on Scripture.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)

--- a/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
+++ b/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
@@ -44,22 +44,27 @@ struct OnboardingForm: View {
     }
 
     private var formContent: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: scaled(24)) {
-                header
-                firstNameSection
-                ageSection
-                contextSection
-                genderSection
-                hobbiesSection
-                optInSection
-                privacyCopy
-                primaryButton
+        ZStack {
+            TimeOfDayTheme.current.backdrop
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: scaled(24)) {
+                    header
+                    firstNameSection
+                    ageSection
+                    contextSection
+                    genderSection
+                    hobbiesSection
+                    optInSection
+                    privacyCopy
+                    primaryButton
+                }
+                .padding(.vertical, scaled(32))
+                .padding(.horizontal, scaled(24))
             }
-            .padding(.vertical, scaled(32))
-            .padding(.horizontal, scaled(24))
+            .scrollContentBackground(.hidden)
         }
-        .background(gradient)
         .onAppear(perform: loadProfile)
         .onChange(of: ageText) {
             if ageError != nil { ageError = nil }
@@ -271,11 +276,6 @@ struct OnboardingForm: View {
             .accessibilityHint("Saves your preferences locally and continues to the app.")
         }
         .padding(.top, scaled(16))
-    }
-
-    private var gradient: some View {
-        LinearGradient(colors: [Color(.systemBackground), Color(.systemBackground).opacity(0.6)], startPoint: .top, endPoint: .bottom)
-            .ignoresSafeArea()
     }
 
     private func loadProfile() {

--- a/WalkWorthy/WalkWorthy/UI/Settings/SettingsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Settings/SettingsView.swift
@@ -56,9 +56,9 @@ struct SettingsView: View {
 
                     Section("Data") {
                         NavigationLink {
-                            MoodHistoryView()
+                            MoodLogView()
                         } label: {
-                            Label("Mood history", systemImage: "chart.line.uptrend.xyaxis")
+                            Label("Check-in log", systemImage: "list.bullet.rectangle")
                         }
                         .listRowBackground(Color.wwCardBackground)
                     }

--- a/WalkWorthy/WalkWorthy/UI/Settings/SettingsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Settings/SettingsView.swift
@@ -53,13 +53,6 @@ struct SettingsView: View {
                             Label("Check-in reminders", systemImage: "bell.badge")
                         }
                         .listRowBackground(Color.wwCardBackground)
-
-                        Button {
-                            appState.scheduleTestNotification()
-                        } label: {
-                            Label("Send test notification", systemImage: "bell")
-                        }
-                        .listRowBackground(Color.wwCardBackground)
                     }
 
                     Section("Data") {

--- a/WalkWorthy/WalkWorthy/UI/Settings/SettingsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Settings/SettingsView.swift
@@ -35,15 +35,14 @@ struct SettingsView: View {
                         }
                         .listRowBackground(Color.wwCardBackground)
 
-                        Picker("Bible translation", selection: Binding(
-                            get: { appState.selectedTranslation },
-                            set: { appState.setTranslation($0) }
-                        )) {
-                            ForEach(Translation.allCases) { translation in
-                                Text(translation.displayName).tag(translation)
-                            }
-                        }
-                        .listRowBackground(Color.wwCardBackground)
+                        // Bible translation picker removed until multi-translation
+                        // content is actually shipped. Today the app uses ESV
+                        // everywhere (Verse of the Day, AI encouragements), so a
+                        // 7-option picker would be misleading. AppState still tracks
+                        // selectedTranslation (default ESV) and the backend schema
+                        // accepts all 7 values, so re-adding the picker is a small
+                        // diff — restore this Picker, setTranslation, and
+                        // syncStoredProfile when real translation content lands.
                     }
 
                     Section("Notifications") {

--- a/functions/src/api/daily-reflection.ts
+++ b/functions/src/api/daily-reflection.ts
@@ -12,6 +12,8 @@ import type { Request, Response } from "express";
 import { getDb, COLLECTIONS, initializeFirebase } from "../shared/firebase";
 import { requireAuth, verifyAppCheck, errorResponse, successResponse } from "../shared/auth";
 import { runReflectionAgent } from "../lib/reflection-agent";
+import { getUserProfileOnce } from "../shared/profile";
+import type { UserProfilePayload } from "../lib/profile-sanitize";
 import type { DailyMoodSummary } from "../shared/types";
 import { checkRateLimit, checkDailyAiBudget, getClientIp, sendRateLimitResponse, DAILY_REFLECTION_USER_LIMIT, DAILY_REFLECTION_IP_LIMIT, REFLECTION_DAILY_AI_BUDGET } from '../shared/rate-limiter';
 
@@ -120,8 +122,18 @@ async function handleGet(req: Request, res: Response): Promise<void> {
       return;
     }
 
+    // Fetch profile for personalization, respecting the opt-in toggle.
+    // Default to personalization ON when optInTailored is undefined, strip
+    // the profile only when explicitly opted out.
+    const profile = await getUserProfileOnce(userId);
+    const useProfile = profile?.optInTailored !== false;
+    if (!useProfile) {
+      logger.info('personalization.optedOut', { userId, endpoint: 'dailyReflection' });
+    }
+    const profileForAgent = useProfile ? (profile as UserProfilePayload | null) : null;
+
     // Generate reflection
-    const reflection = await runReflectionAgent(summaries, openaiApiKey.value());
+    const reflection = await runReflectionAgent(summaries, openaiApiKey.value(), profileForAgent);
     const generatedAt = new Date().toISOString();
     const payload = { reflection, generatedAt, date: today };
 

--- a/functions/src/api/mood-checkin.ts
+++ b/functions/src/api/mood-checkin.ts
@@ -468,8 +468,9 @@ async function handleGetCheckIn(req: Request, res: Response): Promise<void> {
     const profile = await getUserProfileOnce(userId);
     const timezone = profile?.timezone || 'America/New_York';
 
-    // Check for history query
+    // Check for history / fullHistory query (mutually exclusive modes)
     const historyDays = req.query.history ? parseInt(req.query.history as string, 10) : undefined;
+    const fullHistoryDays = req.query.fullHistory ? parseInt(req.query.fullHistory as string, 10) : undefined;
     const startDateParam = req.query.startDate as string | undefined;
     const endDateParam = req.query.endDate as string | undefined;
 
@@ -485,6 +486,10 @@ async function handleGetCheckIn(req: Request, res: Response): Promise<void> {
     if (startDateParam && endDateParam && startDateParam > endDateParam) {
       res.status(400).json({ error: "startDate must not be after endDate." });
       return;
+    }
+
+    if (fullHistoryDays && fullHistoryDays > 0) {
+      return handleGetFullHistory(userId, Math.min(fullHistoryDays, 31), db, timezone, res, startDateParam, endDateParam);
     }
 
     if (historyDays && historyDays > 0) {
@@ -610,5 +615,60 @@ async function handleGetHistory(userId: string, days: number, db: FirebaseFirest
     });
 
     return errorResponse(res, 500, 'Failed to retrieve mood history.');
+  }
+}
+
+/**
+ * Get full check-in documents (with moodSpectrumData, aiResponse, note) for
+ * the past N days. Powers the Settings → Check-in log deep-dive view.
+ *
+ * Uses the deterministic doc-id invariant (one doc per day per check-in type,
+ * max 3 per day) to cap the query size at days * 3. Within a day the iOS
+ * client reorders by check-in type (morning → midday → evening).
+ */
+async function handleGetFullHistory(userId: string, days: number, db: FirebaseFirestore.Firestore, timezone: string, res: Response, startDateOverride?: string, endDateOverride?: string): Promise<void> {
+  try {
+    const now = new Date();
+    const startDate = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    const startDateString = startDateOverride ?? getDateStringInTimezone(startDate, timezone);
+
+    let query = db
+      .collection(COLLECTIONS.users)
+      .doc(userId)
+      .collection('moodCheckIns')
+      .where('date', '>=', startDateString)
+      .orderBy('date', 'desc');
+
+    if (endDateOverride) {
+      query = query.where('date', '<=', endDateOverride);
+    }
+
+    const checkInsQuery = await query
+      .limit(days * 3) // morning/midday/evening per day is the upper bound
+      .get();
+
+    const checkIns: MoodCheckIn[] = checkInsQuery.docs.map(
+      (doc) => doc.data() as MoodCheckIn,
+    );
+
+    logger.info('Mood full history retrieved', {
+      userId,
+      days,
+      timezone,
+      startDateString,
+      count: checkIns.length,
+    });
+
+    return successResponse(res, {
+      checkIns,
+      daysRequested: days,
+    });
+  } catch (error) {
+    logger.error('Get full history failed', {
+      userId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+
+    return errorResponse(res, 500, 'Failed to retrieve check-in log.');
   }
 }

--- a/functions/src/api/mood-checkin.ts
+++ b/functions/src/api/mood-checkin.ts
@@ -307,8 +307,15 @@ async function handlePostCheckIn(req: Request, res: Response): Promise<void> {
     }
 
     // Step 2: Generate AI response (outside transaction - may take time)
+    // Respect the user's "Use profile for encouragements" toggle: default to
+    // personalization ON when the flag is undefined (matches iOS onboarding
+    // default), strip the profile only when explicitly opted out.
+    const useProfile = profile?.optInTailored !== false;
+    if (!useProfile) {
+      logger.info('personalization.optedOut', { userId, endpoint: 'moodCheckIn' });
+    }
     const agentInput: MoodAgentInput = {
-      profile: profile as UserProfilePayload | null,
+      profile: useProfile ? (profile as UserProfilePayload | null) : null,
       checkInType: input.checkInType,
       moodSpectrumData: input.moodSpectrumData,
       translationPreference: translation,

--- a/functions/src/api/user-profile.ts
+++ b/functions/src/api/user-profile.ts
@@ -76,6 +76,7 @@ export const userProfile = onRequest(httpsOptions, async (req, res) => {
 
         const profileData: UserProfile = {
           ageRange: validated.ageRange,
+          firstName: validated.firstName,
           gender: validated.gender,
           major: validated.major,
           occupation: validated.occupation,
@@ -112,6 +113,24 @@ export const userProfile = onRequest(httpsOptions, async (req, res) => {
             return errorResponse(res, 400, 'Invalid gender value');
           }
           updates.gender = validGender;
+        }
+
+        if (req.body.firstName !== undefined) {
+          if (req.body.firstName === null) {
+            updates.firstName = FieldValue.delete() as unknown as string | undefined;
+          } else if (typeof req.body.firstName === 'string') {
+            const trimmed = req.body.firstName.trim();
+            if (trimmed.length === 0) {
+              // Empty string clears the field (client convenience: some UIs can't send null)
+              updates.firstName = FieldValue.delete() as unknown as string | undefined;
+            } else if (trimmed.length <= 60) {
+              updates.firstName = trimmed;
+            } else {
+              return errorResponse(res, 400, 'Invalid firstName value');
+            }
+          } else {
+            return errorResponse(res, 400, 'Invalid firstName value');
+          }
         }
 
         if (req.body.major !== undefined) {

--- a/functions/src/lib/mood-agent.ts
+++ b/functions/src/lib/mood-agent.ts
@@ -12,31 +12,24 @@ import { z } from "zod";
 import Ajv from "ajv";
 import { logger } from "firebase-functions/v2";
 import type {
-  AgeRange,
-  Gender,
   CheckInType,
   Translation,
   AIEncouragementResponse,
   MoodSpectrumData,
 } from "../shared/types";
-import { validateAgeRange, validateGender } from "../shared/types";
+import {
+  sanitizeProfile,
+  sanitizeText,
+  type UserProfilePayload,
+} from "./profile-sanitize";
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export interface UserProfilePayload {
-  /** SENSITIVE: Optional major/field of study (for students). Can identify users when combined with other profile data. */
-  major?: string;
-  /** SENSITIVE: Optional occupation/job title (for non-students). Can identify users when combined with other profile data. */
-  occupation?: string;
-  /** SENSITIVE: Gender is PII; must be one of the predefined gender options */
-  gender?: Gender;
-  /** SENSITIVE: Age range is PII; must be one of the predefined ranges */
-  ageRange?: AgeRange;
-  hobbies?: string[];
-  optInTailored?: boolean;
-}
+// Re-export UserProfilePayload for backwards compatibility with consumers
+// (e.g., api/mood-checkin.ts) that previously imported it from this module.
+export type { UserProfilePayload } from "./profile-sanitize";
 
 export interface MoodAgentInput {
   profile: UserProfilePayload | null;
@@ -160,6 +153,29 @@ For score=5, tags=["Calm","Steady"], categories=["Tasks"], midday, followUpScore
   "translation": "NIV"
 }
 
+## Using the User Profile (SUBTLE CONTEXT ONLY)
+
+You may receive a "profile" object with optional fields: ageRange, occupation, major, gender, hobbies. Treat this as SILENT CONTEXT that quietly shapes your response — never as material to name or list back.
+
+**DO:**
+- Let ageRange, occupation/major, and hobbies inform your TONE, IMAGERY, and VERSE CHOICE. A verse about diligence hits differently for a grad student than for a retiree.
+- Match life-stage vocabulary naturally: "exam season" or "before class" for students; "Monday morning" or "project deadline" for working professionals; "the week ahead" when unclear.
+- Pick imagery that resonates with their world without announcing it (e.g., for someone with outdoor hobbies, a verse about God's creation may land more than one about city streets).
+
+**DON'T:**
+- Name-drop hobbies, major, occupation, gender, or age. Never write "As a nursing student…", "I know you love reading…", or "Hey engineer,".
+- List the user's profile back to them in any form.
+- Mention that a profile or personalization exists.
+- Refer to the user by an identity label or role.
+
+**Contrast example** — profile: {ageRange: "18-24", major: "Nursing", hobbies: ["Music","Reading"]}, morning, score=3, tags=["Anxious"]:
+
+BAD (name-dropping): "Hey nursing student, clinicals are tough. Maybe put on some music later."
+
+GOOD (subtle): "Mornings before a heavy day can feel like the whole weight lands before you've even started. You don't have to carry all of it right now."
+
+If the profile is null or empty, fall back to neutral, universally-applicable warmth.
+
 ## Output Requirements
 - Output STRICT JSON matching the schema {message, verseRef, verseText, translation}
 - No prose, explanations, or code fences - just the JSON object
@@ -190,38 +206,8 @@ function ensureConfig(apiKey: string) {
 // ============================================================================
 // Input Sanitization
 // ============================================================================
-
-function sanitize(text: string, max = 400): string {
-  const stripped = text
-    .replace(/<[^>]+>/g, " ")
-    .replace(/https?:\/\/\S+/gi, " ");
-  return stripped.replace(/\s+/g, " ").trim().slice(0, max);
-}
-
-function sanitizeProfile(
-  profile: UserProfilePayload | null | undefined,
-): UserProfilePayload | null {
-  if (!profile) return null;
-
-  // Validate sensitive enum fields to prevent invalid data being passed to AI
-  const validGender = profile.gender
-    ? validateGender(profile.gender)
-    : undefined;
-  const validAgeRange = profile.ageRange
-    ? validateAgeRange(profile.ageRange)
-    : undefined;
-
-  return {
-    major: profile.major ? sanitize(profile.major, 120) : undefined,
-    occupation: profile.occupation
-      ? sanitize(profile.occupation, 120)
-      : undefined,
-    gender: validGender,
-    ageRange: validAgeRange,
-    hobbies: profile.hobbies?.slice(0, 6).map((h) => sanitize(h, 40)),
-    optInTailored: Boolean(profile.optInTailored),
-  };
-}
+// sanitizeProfile() and sanitizeText() live in ./profile-sanitize so the
+// reflection agent can share the same sanitization logic.
 
 function normalizeTranslation(value: Translation | string): Translation {
   const upper = value.toUpperCase() as Translation;
@@ -315,10 +301,10 @@ export async function runMoodAgent(
     checkInType: input.checkInType,
     moodScore: moodSpectrumData.moodScore,
     moodLevel: moodSpectrumData.moodLevel,
-    emotionTags: moodSpectrumData.emotionTags.slice(0, 10).map((t) => sanitize(t, 30)),
-    impactCategories: moodSpectrumData.impactCategories.slice(0, 10).map((c) => sanitize(c, 30)),
+    emotionTags: moodSpectrumData.emotionTags.slice(0, 10).map((t) => sanitizeText(t, 30)),
+    impactCategories: moodSpectrumData.impactCategories.slice(0, 10).map((c) => sanitizeText(c, 30)),
     followUpScore: moodSpectrumData.followUpScore,
-    note: moodSpectrumData.note ? sanitize(moodSpectrumData.note, 300) : undefined,
+    note: moodSpectrumData.note ? sanitizeText(moodSpectrumData.note, 300) : undefined,
   };
 
   const serializedInput = JSON.stringify(payload, null, 2);

--- a/functions/src/lib/profile-sanitize.ts
+++ b/functions/src/lib/profile-sanitize.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared profile + text sanitization helpers used by AI agents.
+ *
+ * Extracted from mood-agent.ts so the reflection agent can use the same
+ * sanitization logic without duplication. Preserves existing behavior:
+ *   - Text fields capped at 120 chars (major/occupation) or 40 chars (hobbies)
+ *   - Hobbies list capped at 6 entries
+ *   - Strips HTML tags and URLs
+ *   - Validates gender/ageRange via shared type validators
+ */
+
+import type { AgeRange, Gender } from "../shared/types";
+import { validateAgeRange, validateGender } from "../shared/types";
+
+/**
+ * Profile payload shape as consumed by AI agents. Mirrors a subset of
+ * shared/profile.ts::UserProfile but includes only fields the AI should see.
+ */
+export interface UserProfilePayload {
+  /** SENSITIVE: Optional major/field of study (for students). Can identify users when combined with other profile data. */
+  major?: string;
+  /** SENSITIVE: Optional occupation/job title (for non-students). Can identify users when combined with other profile data. */
+  occupation?: string;
+  /** SENSITIVE: Gender is PII; must be one of the predefined gender options */
+  gender?: Gender;
+  /** SENSITIVE: Age range is PII; must be one of the predefined ranges */
+  ageRange?: AgeRange;
+  hobbies?: string[];
+  optInTailored?: boolean;
+}
+
+/**
+ * General-purpose text sanitizer: strips HTML tags and URLs, collapses
+ * whitespace, and truncates to `max` characters.
+ */
+export function sanitizeText(text: string, max = 400): string {
+  const stripped = text
+    .replace(/<[^>]+>/g, " ")
+    .replace(/https?:\/\/\S+/gi, " ");
+  return stripped.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/**
+ * Sanitize a user profile for safe inclusion in AI agent input.
+ *
+ * Validates sensitive enum fields (gender, ageRange) and caps free-form
+ * text fields. Returns null when the profile is null/undefined.
+ */
+export function sanitizeProfile(
+  profile: UserProfilePayload | null | undefined,
+): UserProfilePayload | null {
+  if (!profile) return null;
+
+  // Validate sensitive enum fields to prevent invalid data being passed to AI
+  const validGender = profile.gender
+    ? validateGender(profile.gender)
+    : undefined;
+  const validAgeRange = profile.ageRange
+    ? validateAgeRange(profile.ageRange)
+    : undefined;
+
+  return {
+    major: profile.major ? sanitizeText(profile.major, 120) : undefined,
+    occupation: profile.occupation
+      ? sanitizeText(profile.occupation, 120)
+      : undefined,
+    gender: validGender,
+    ageRange: validAgeRange,
+    hobbies: profile.hobbies?.slice(0, 6).map((h) => sanitizeText(h, 40)),
+    optInTailored: Boolean(profile.optInTailored),
+  };
+}

--- a/functions/src/lib/reflection-agent.ts
+++ b/functions/src/lib/reflection-agent.ts
@@ -10,6 +10,10 @@ import { setDefaultOpenAIKey, setOpenAIAPI } from "@openai/agents-openai";
 import { z } from "zod";
 import { logger } from "firebase-functions/v2";
 import type { DailyMoodSummary } from "../shared/types";
+import {
+  sanitizeProfile,
+  type UserProfilePayload,
+} from "./profile-sanitize";
 
 // ============================================================================
 // Output Schema
@@ -35,6 +39,20 @@ Given a summary of the student's mood check-ins over the past week, write a shor
 - Conversational and warm — like a trusted friend, not a pastor or therapist
 - Scripture-adjacent in spirit without quoting specific verses (encouragements elsewhere in the app handle that)
 - Specific enough to feel personal, not generic enough to feel like a form letter
+
+## Using the User Profile (SUBTLE CONTEXT ONLY)
+You may receive a "profile" object with optional fields: ageRange, occupation, major, gender, hobbies. Treat this as SILENT CONTEXT that shapes TONE and IMAGERY — never as material to name or list back.
+
+**DO:**
+- Let ageRange, occupation/major, and hobbies inform your word choice and the season-of-life texture of your reflection (e.g., "a week of long study hours" vs. "a week of meeting after meeting").
+- Choose resonant imagery without announcing it.
+
+**DON'T:**
+- Name-drop hobbies, major, occupation, gender, or age.
+- List the user's profile back to them.
+- Refer to the user by an identity label ("Hey engineer,", "As a student…").
+
+If the profile is null or empty, fall back to neutral, universally-applicable warmth.
 
 ## Output
 Return a single JSON object: { "reflection": "your 2-3 sentence reflection here" }
@@ -69,20 +87,26 @@ function ensureAgent(apiKey: string): Agent<object, typeof reflectionOutputSchem
 // Input Builder
 // ============================================================================
 
-function buildPrompt(summaries: DailyMoodSummary[]): string {
-  if (summaries.length === 0) {
-    return JSON.stringify({ weekSummary: "No check-ins recorded this week." });
-  }
+function buildPrompt(
+  summaries: DailyMoodSummary[],
+  profile: UserProfilePayload | null,
+): string {
+  const weekSummary =
+    summaries.length === 0
+      ? "No check-ins recorded this week."
+      : summaries.map((s) => ({
+          date: s.date,
+          sentiment: s.overallSentiment ?? "unknown",
+          morning: s.morning?.moodLevel ?? null,
+          midday: s.midday?.moodLevel ?? null,
+          evening: s.evening?.moodLevel ?? null,
+        }));
 
-  const entries = summaries.map((s) => ({
-    date: s.date,
-    sentiment: s.overallSentiment ?? "unknown",
-    morning: s.morning?.moodLevel ?? null,
-    midday: s.midday?.moodLevel ?? null,
-    evening: s.evening?.moodLevel ?? null,
-  }));
-
-  return JSON.stringify({ weekSummary: entries }, null, 2);
+  return JSON.stringify(
+    { profile: sanitizeProfile(profile), weekSummary },
+    null,
+    2,
+  );
 }
 
 // ============================================================================
@@ -92,13 +116,15 @@ function buildPrompt(summaries: DailyMoodSummary[]): string {
 export async function runReflectionAgent(
   summaries: DailyMoodSummary[],
   apiKey: string,
+  profile: UserProfilePayload | null = null,
 ): Promise<string> {
   logger.info("[ReflectionAgent] Generating daily reflection", {
     summaryCount: summaries.length,
+    hasProfile: profile !== null,
   });
 
   const agent = ensureAgent(apiKey);
-  const input = buildPrompt(summaries);
+  const input = buildPrompt(summaries, profile);
 
   let lastError: unknown;
   for (let attempt = 0; attempt < 2; attempt++) {

--- a/functions/src/shared/profile.ts
+++ b/functions/src/shared/profile.ts
@@ -5,6 +5,13 @@ export interface UserProfile {
   /** SENSITIVE: Stored PII - use redactSensitiveFields() when logging */
   ageRange?: AgeRange;
 
+  /**
+   * OPTIONAL - SENSITIVE: User's first name for Home-view greeting personalization.
+   * NOT passed to AI agents — see profile-sanitize.ts::UserProfilePayload which
+   * intentionally omits this field.
+   */
+  firstName?: string;
+
   /** SENSITIVE: Optional major/field of study (for students). Can identify users when combined with other profile data. */
   major?: string;
 

--- a/functions/src/shared/types.ts
+++ b/functions/src/shared/types.ts
@@ -30,6 +30,12 @@ export interface UserProfileInput {
   /** REQUIRED - SENSITIVE: Must be one of the predefined age ranges */
   ageRange: AgeRange;
 
+  /**
+   * OPTIONAL - SENSITIVE: User's first name for Home-view greeting personalization.
+   * NOT passed to AI agents. Validated: trimmed, 1–60 chars.
+   */
+  firstName?: string;
+
   /** OPTIONAL - SENSITIVE: major/field of study (for students). May be free-form but should be validated. */
   major?: string;
 
@@ -150,6 +156,15 @@ export function validateUserProfileInput(input: unknown): UserProfileInput | und
     checkInTimes = validateCheckInTimes(obj.checkInTimes);
   }
 
+  // OPTIONAL: Validate firstName (trim + length 1–60 when present)
+  let firstName: string | undefined;
+  if (typeof obj.firstName === 'string') {
+    const trimmed = obj.firstName.trim();
+    if (trimmed.length > 0 && trimmed.length <= 60) {
+      firstName = trimmed;
+    }
+  }
+
   return {
     ageRange,
     gender,
@@ -158,6 +173,7 @@ export function validateUserProfileInput(input: unknown): UserProfileInput | und
     translationPreference: translationPref,
     timezone,
     // Optional fields
+    firstName,
     major: typeof obj.major === 'string' ? obj.major.slice(0, 120) : undefined,
     occupation: typeof obj.occupation === 'string' ? obj.occupation.slice(0, 120) : undefined,
     checkInTimes,


### PR DESCRIPTION
## Summary

- **Backend personalization:** user profile (age, occupation, major, hobbies) now actually influences AI encouragements (subtle, no name-drops per the system prompt) and the reflection agent. The `optInTailored` toggle is finally enforced — flipping it off strips the profile from agent calls and fires `personalization.optedOut` logs.
- **iOS personalization (Phase 2):** new optional `firstName` field end-to-end (Swift models + TS backend + PUT/PATCH). Home greeting reads "Good morning, Nathan" when set; tone-aware subtitle varies student / professional / default based on identity markers. Dismissible backfill banner for existing users. `firstName` is deliberately not sent to the AI.
- **Check-in Log deep-dive view:** Settings → Check-in log is a new day-grouped feed showing every check-in with full context (mood level, emotion tags, impact categories, note, AI encouragement) and linked journal entries nested beneath. Backed by a new `GET /moodCheckIn?fullHistory=N` endpoint. History tab untouched.
- **Honest cleanup:** removed the misleading 7-translation picker (labeled Verse of the Day as "· ESV" since that's what's actually shipped), removed the unused "Send test notification" button and its plumbing, applied Newsreader + time-of-day theme to OnboardingForm, fixed unreadable error overlay text in CinematicTransitionView.

9 commits; see history for per-change detail.

## Test plan

**Backend**
- [ ] `cd functions && npm run build` clean
- [ ] Deploy via CI on merge; `firebase functions:log` shows `[ReflectionAgent] Generating daily reflection` with `hasProfile` field present (Phase 1 deploy verification)
- [ ] `GET /moodCheckIn?fullHistory=14` returns `{ checkIns: MoodCheckIn[], daysRequested }` with full `moodSpectrumData` + `aiResponse`
- [ ] Existing `?history=N` path still returns summaries unchanged
- [ ] PATCH `/userProfile` with `firstName` persists; null/empty clears

**iOS — Personalization**
- [ ] New onboarding with firstName set → Home greeting shows name
- [ ] New onboarding skipping firstName → backfill banner appears on Home
- [ ] Banner × dismiss → stays hidden across relaunch
- [ ] Add name via Settings → banner disappears, greeting personalizes
- [ ] Profile with `major` → student-tone subtitle; profile with `occupation` only → professional-tone
- [ ] Settings: Bible translation picker is gone; "Send test notification" is gone; Verse of the Day shows "· ESV"
- [ ] OnboardingForm in all 3 entry points (onboarding, Settings → Edit personal details, backfill-banner sheet) shows Newsreader headings and time-of-day backdrop
- [ ] Error states in mood check-in show legible black text on light error overlay

**iOS — Check-in Log**
- [ ] Settings → "Check-in log" opens the new view with last 14 days
- [ ] Each check-in card shows type icon + mood pill + score + tags + impacts + note (if present) + AI message + verse ref + verse text
- [ ] Journal entry created alongside a check-in appears nested in that check-in's card
- [ ] Standalone journal entry (no `linkedCheckInId`) appears under the day header
- [ ] Tap a journal row → opens `JournalEditorView`
- [ ] "Load older (14 more days)" paginates; "That's the beginning of your log" eventually appears
- [ ] Pull-to-refresh reloads first page
- [ ] Empty-state copy renders for new users with zero check-ins
- [ ] History tab (`MoodHistoryView`) still works as before — chart + week overview + Latest Encouragement card

**Opt-in regression**
- [ ] Flip Settings → "Use profile for encouragements" off → `firebase functions:log` shows `personalization.optedOut` on next check-in / reflection; AI output becomes neutral

🤖 Generated with [Claude Code](https://claude.com/claude-code)