### PR TITLE
chore(backend): Firestore TTL on _dailyBudgets + _rateLimits

### DIFF
--- a/functions/src/shared/rate-limiter.ts
+++ b/functions/src/shared/rate-limiter.ts
@@ -1,4 +1,5 @@
 import type { Firestore } from 'firebase-admin/firestore';
+import { Timestamp } from 'firebase-admin/firestore';
 import type { Request, Response } from 'express';
 import { logger } from 'firebase-functions/v2';
 
@@ -59,11 +60,13 @@ export function sendRateLimitResponse(
 interface RateLimitDoc {
   timestamps: string[];
   updatedAt: string;
+  expiresAt?: FirebaseFirestore.Timestamp;
 }
 
 interface DailyBudgetDoc {
   callCount: number;
   date: string;
+  expiresAt?: FirebaseFirestore.Timestamp;
 }
 
 // AI endpoints (expensive)
@@ -115,9 +118,11 @@ export async function checkRateLimit(
 
       const nowIso = new Date(now).toISOString();
       const updatedTimestamps = [...windowTimestamps, nowIso];
+      // Firestore TTL policy on `_rateLimits.expiresAt` auto-deletes stale docs — see README / Firestore Console.
       const updatedDoc: RateLimitDoc = {
         timestamps: updatedTimestamps,
         updatedAt: nowIso,
+        expiresAt: Timestamp.fromMillis(now + config.windowMs + 60 * 60 * 1000),
       };
       tx.set(docRef, updatedDoc);
 
@@ -147,8 +152,11 @@ export async function checkDailyAiBudget(
     return await db.runTransaction(async (tx) => {
       const snap = await tx.get(docRef);
 
+      // Firestore TTL policy on `_dailyBudgets.expiresAt` auto-deletes stale docs — see README / Firestore Console.
+      const expiresAt = Timestamp.fromMillis(Date.now() + 48 * 60 * 60 * 1000);
+
       if (!snap.exists) {
-        const newDoc: DailyBudgetDoc = { callCount: 1, date: today };
+        const newDoc: DailyBudgetDoc = { callCount: 1, date: today, expiresAt };
         tx.set(docRef, newDoc);
         return { allowed: true, remaining: maxCallsPerDay - 1 };
       }
@@ -157,7 +165,7 @@ export async function checkDailyAiBudget(
 
       if (data.date !== today) {
         // Stale document from a previous day — reset
-        const resetDoc: DailyBudgetDoc = { callCount: 1, date: today };
+        const resetDoc: DailyBudgetDoc = { callCount: 1, date: today, expiresAt };
         tx.set(docRef, resetDoc);
         return { allowed: true, remaining: maxCallsPerDay - 1 };
       }
@@ -167,7 +175,7 @@ export async function checkDailyAiBudget(
       }
 
       const updatedCount = data.callCount + 1;
-      tx.update(docRef, { callCount: updatedCount });
+      tx.update(docRef, { callCount: updatedCount, expiresAt });
       return { allowed: true, remaining: maxCallsPerDay - updatedCount };
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Stamp `expiresAt: Timestamp` on every write to `_dailyBudgets` and `_rateLimits` so Firestore's native TTL feature can auto-delete stale counter docs.
- `_dailyBudgets`: `now + 48h` — enough slack for UTC/timezone edges, guarantees yesterday's doc is gone before it could matter.
- `_rateLimits`: `now + windowMs + 1h` — a doc untouched longer than its sliding window is stale by definition.

## Why
Both collections write one doc per user per day (or per user+endpoint) and nothing deletes them. At 1000 users `_dailyBudgets` alone grows ~365K docs/year. Storage cost is negligible, but the Console becomes a swamp and GDPR deletions get painful. Native TTL is free, runs in the background, and needs no cron function.

## Deploy + TTL status (already done)
- Functions deployed to prod from this branch (`firebase deploy --only functions`).
- TTL policies created in Google Cloud Console and are currently "Building":
  - `_dailyBudgets.expiresAt`
  - `_rateLimits.expiresAt`
- Merging this PR keeps main in sync with prod so the next CI deploy from main doesn't strip the `expiresAt` writes.

## Out of scope (intentionally untouched)
- `moodCheckIns` / `moodSummaries` / `dailyReflections` — users expect long-term history.
- Rate-limit thresholds (`MOOD_DAILY_AI_BUDGET` etc.).
- Fail-open error handling in both functions.

## Test plan
- [x] `cd functions && npm run build` — clean
- [x] Grep confirms every `tx.set` / `tx.update` touching `_dailyBudgets` or `_rateLimits` now includes `expiresAt`
- [x] Functions deployed successfully to prod
- [ ] Once TTL policies flip from Building → Active, observe stale docs in `_dailyBudgets` older than 48h start disappearing within ~24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)