### PR TITLE
chore: launch-blocker cleanup — real support email + Crashlytics wiring

### DIFF
--- a/WalkWorthy/WalkWorthy/App/AppState.swift
+++ b/WalkWorthy/WalkWorthy/App/AppState.swift
@@ -769,8 +769,9 @@ final class AppState: ObservableObject {
             journalError = "Couldn't load your journal entries. Please try again."
             #if DEBUG
             print("[AppState] loadJournalEntries failed: \(error)")
+            #else
+            Crashlytics.crashlytics().record(error: error)
             #endif
-            // TODO: If Crashlytics is added later, record non-fatal here.
         }
     }
 

--- a/WalkWorthy/WalkWorthy/UI/Components/ConfigurationErrorView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Components/ConfigurationErrorView.swift
@@ -12,8 +12,7 @@ import SwiftUI
 struct ConfigurationErrorView: View {
     let message: String
 
-    // TODO: Replace with the real support address before App Store launch.
-    private static let supportEmail = "support@walkworthy.app"
+    private static let supportEmail = "walkworthyofficial@gmail.com"
 
     private var supportURL: URL? {
         URL(string: "mailto:\(Self.supportEmail)")

--- a/WalkWorthy/WalkWorthy/UI/Journal/JournalEditorView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/JournalEditorView.swift
@@ -168,7 +168,6 @@ struct JournalEditorView: View {
                         #else
                         Crashlytics.crashlytics().record(error: error)
                         #endif
-                        // TODO: Crashlytics.record(error) once Crashlytics is wired up.
                     }
                 }
             }

--- a/WalkWorthy/WalkWorthy/UI/Journal/JournalListView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/JournalListView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import SwiftData
 import UIKit
+import FirebaseCrashlytics
 
 /// Top-level wrapper that reads the current `authenticatedUserSub` from
 /// `AppState` and passes it into the content view. The content view takes the
@@ -125,8 +126,9 @@ private struct JournalListContent: View {
                         deleteError = "Couldn't delete that note. Please try again."
                         #if DEBUG
                         print("[JournalListView] delete failed: \(error)")
+                        #else
+                        Crashlytics.crashlytics().record(error: error)
                         #endif
-                        // TODO: Crashlytics.record(error) when Crashlytics is added.
                     }
                 }
                 entryPendingDelete = nil


### PR DESCRIPTION
## Summary
- Swap placeholder `support@walkworthy.app` for the real `walkworthyofficial@gmail.com` in `ConfigurationErrorView` — TODO explicitly flagged this as a pre-launch blocker. Users who hit the startup error screen can now actually reach us.
- Wire Crashlytics non-fatal record in three previously-silent error paths (`AppState.loadJournalEntries`, `JournalListView` delete-catch, `JournalEditorView` delete-catch comment cleanup). Crashlytics is already imported and used in four other call sites — these TODOs were stale.

No behavior change in DEBUG. In RELEASE, we now get non-fatal telemetry on real-world frequency of journal fetch/delete failures once on the App Store.

## Test plan
- [ ] Build Release locally, trigger a journal delete failure (e.g. simulator with no disk space), confirm Crashlytics logs it
- [ ] Confirm `ConfigurationErrorView` mailto link opens `walkworthyofficial@gmail.com` (only reachable if startup config fails — not expected to trigger in normal use)
- [ ] CI green (Firebase deploy workflow + Xcode Cloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)