### PR TITLE
feat: photorealistic Apple Weather-style mood background

### DIFF
--- a/WalkWorthy/WalkWorthy/Helpers/TimeOfDayTheme.swift
+++ b/WalkWorthy/WalkWorthy/Helpers/TimeOfDayTheme.swift
@@ -70,6 +70,16 @@ struct TimeOfDayTheme {
         }
     }
 
+    // Interactive accent (selected chips, primary buttons) — harmonized with
+    // each backdrop so controls feel lit by the same scene as the hero image.
+    var accent: Color {
+        switch timeOfDay {
+        case .morning: return Self.morningAccent
+        case .midday:  return Self.middayAccent
+        case .night:   return Self.nightAccent
+        }
+    }
+
     // MARK: - Palette (sRGB, tuned for dark-mode legibility)
 
     // Morning
@@ -83,6 +93,11 @@ struct TimeOfDayTheme {
     private static let middayGreenBottom = Color(red: 0.059, green: 0.118, blue: 0.090) // #0F1E17
     private static let middayCard        = Color(red: 0.106, green: 0.176, blue: 0.141) // #1B2D24
     private static let middayRecessed    = Color(red: 0.063, green: 0.114, blue: 0.086) // #101D16
+
+    // Accents
+    private static let morningAccent = Color(red: 0.788, green: 0.502, blue: 0.286) // #C98049 (sunrise amber)
+    private static let middayAccent  = Color(red: 0.302, green: 0.549, blue: 0.361) // #4D8C5C (meadow green)
+    private static let nightAccent   = Color(red: 0.329, green: 0.451, blue: 0.651) // #5473A6 (slate blue)
 }
 
 extension Color {

--- a/WalkWorthy/WalkWorthy/UI/Mood/EmotionTagsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/EmotionTagsView.swift
@@ -56,7 +56,7 @@ struct EmotionTagsView: View {
                                 ChipButton(
                                     label: tag,
                                     isSelected: selectedTags.contains(tag),
-                                    selectedColor: chipColor(for: moodLevel)
+                                    selectedColor: TimeOfDayTheme.current.accent
                                 ) {
                                     toggleTag(tag)
                                 }
@@ -75,7 +75,7 @@ struct EmotionTagsView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, scaled(14))
-                        .background(chipColor(for: moodLevel))
+                        .background(TimeOfDayTheme.current.accent)
                         .cornerRadius(scaled(30))
                 }
                 .padding(.horizontal, scaled(24))
@@ -127,17 +127,6 @@ func moodLevelToScore(_ level: MoodLevel) -> Double {
     case .neutral: return 0.5
     case .pleasant: return 0.7
     case .veryPleasant: return 0.9
-    }
-}
-
-/// Returns the chip fill color for a given mood level.
-func chipColor(for level: MoodLevel) -> Color {
-    switch level {
-    case .veryUnpleasant: return Color(red: 0.45, green: 0.25, blue: 0.60) // purple
-    case .unpleasant:     return Color(red: 0.44, green: 0.50, blue: 0.56) // slate
-    case .neutral:        return Color(red: 0.25, green: 0.60, blue: 0.58) // teal
-    case .pleasant:       return Color(red: 0.85, green: 0.65, blue: 0.20) // amber
-    case .veryPleasant:   return Color(red: 0.42, green: 0.68, blue: 0.30) // green
     }
 }
 

--- a/WalkWorthy/WalkWorthy/UI/Mood/ImpactCategoriesView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/ImpactCategoriesView.swift
@@ -64,7 +64,7 @@ struct ImpactCategoriesView: View {
                                 ChipButton(
                                     label: category,
                                     isSelected: selectedCategories.contains(category),
-                                    selectedColor: chipColor(for: moodLevel)
+                                    selectedColor: TimeOfDayTheme.current.accent
                                 ) {
                                     toggleCategory(category)
                                 }
@@ -83,7 +83,7 @@ struct ImpactCategoriesView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, scaled(14))
-                        .background(chipColor(for: moodLevel))
+                        .background(TimeOfDayTheme.current.accent)
                         .cornerRadius(scaled(30))
                 }
                 .padding(.horizontal, scaled(24))

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodCheckInView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodCheckInView.swift
@@ -35,8 +35,11 @@ struct MoodCheckInView: View {
     /// On-device representation of an in-progress check-in. Persisted per-user
     /// and per-check-in-type so a network failure mid-wizard doesn't erase the
     /// user's selections. Cleared on successful submission.
+    ///
+    /// The slider position is deliberately NOT persisted: the wizard always
+    /// reopens on the slider step, and the mood should start at dead-center
+    /// neutral each time rather than wherever the user last left it.
     private struct Draft: Codable {
-        var sliderValue: Double
         var selectedTags: [String]
         var selectedCategories: [String]
         var followUpScore: Int
@@ -86,7 +89,6 @@ struct MoodCheckInView: View {
             // UserDefaults write per edit — and avoids needing to plumb
             // "save draft" callbacks through every step view.
             .onChange(of: step) { _, _ in saveDraft() }
-            .onChange(of: sliderValue) { _, _ in saveDraft() }
             .onChange(of: selectedTags) { _, _ in saveDraft() }
             .onChange(of: selectedCategories) { _, _ in saveDraft() }
             .onChange(of: followUpScore) { _, _ in saveDraft() }
@@ -263,7 +265,6 @@ struct MoodCheckInView: View {
         guard step != .cinematic, let key = draftKey() else { return }
 
         let draft = Draft(
-            sliderValue: sliderValue,
             selectedTags: selectedTags,
             selectedCategories: selectedCategories,
             followUpScore: followUpScore,
@@ -286,7 +287,6 @@ struct MoodCheckInView: View {
               let draft = try? Self.draftDecoder.decode(Draft.self, from: data)
         else { return }
 
-        sliderValue = draft.sliderValue
         selectedTags = draft.selectedTags
         selectedCategories = draft.selectedCategories
         followUpScore = draft.followUpScore

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodFollowUpView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodFollowUpView.swift
@@ -66,7 +66,7 @@ struct MoodFollowUpView: View {
                                         .foregroundColor(isSelected ? .white : .primary)
                                         .background(
                                             RoundedRectangle(cornerRadius: scaled(12))
-                                                .fill(isSelected ? chipColor(for: moodLevel) : Color.clear)
+                                                .fill(isSelected ? TimeOfDayTheme.current.accent : Color.clear)
                                         )
                                         .overlay(
                                             RoundedRectangle(cornerRadius: scaled(12))
@@ -120,7 +120,7 @@ struct MoodFollowUpView: View {
                         .padding(.vertical, scaled(14))
                         .background(
                             followUpScore > 0
-                                ? chipColor(for: moodLevel)
+                                ? TimeOfDayTheme.current.accent
                                 : Color.secondary.opacity(0.3)
                         )
                         .cornerRadius(scaled(30))

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodWeatherBackground.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodWeatherBackground.swift
@@ -38,7 +38,9 @@ struct WeatherParameters {
         nearCloudCoverage = Self.lerp([0.97, 0.90, 0.82, 0.42, 0.10], at: t)
         nearCloudDarkness = Self.lerp([0.95, 0.72, 0.45, 0.10, 0.00], at: t)
         cloudVerticalFade = Self.lerp([1.25, 1.15, 1.05, 0.78, 0.55], at: t)
-        windSpeed = Self.lerp([0.040, 0.026, 0.016, 0.012, 0.009], at: t)
+        // Tuned for clearly visible drift (Apple Weather pace): ~35 pt/s in a
+        // storm down to ~7 pt/s for fair-weather wisps on a 393pt screen.
+        windSpeed = Self.lerp([0.180, 0.120, 0.085, 0.055, 0.035], at: t)
         rainIntensity = Self.lerp([1.00, 0.55, 0.10, 0.00, 0.00], at: t)
         lightningIntensity = Self.lerp([1.00, 0.00, 0.00, 0.00, 0.00], at: t)
         sunStrength = Self.lerp([0.00, 0.00, 0.10, 0.62, 1.00], at: t)

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodWeatherBackground.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodWeatherBackground.swift
@@ -41,7 +41,9 @@ struct WeatherParameters {
         // Tuned for clearly visible drift (Apple Weather pace): ~35 pt/s in a
         // storm down to ~7 pt/s for fair-weather wisps on a 393pt screen.
         windSpeed = Self.lerp([0.180, 0.120, 0.085, 0.055, 0.035], at: t)
-        rainIntensity = Self.lerp([1.00, 0.55, 0.10, 0.00, 0.00], at: t)
+        // Zero by neutral — sqrt-based drop counts amplify small intensities,
+        // so even a 0.1 "drizzle" here reads as real rain on screen.
+        rainIntensity = Self.lerp([1.00, 0.55, 0.00, 0.00, 0.00], at: t)
         lightningIntensity = Self.lerp([1.00, 0.00, 0.00, 0.00, 0.00], at: t)
         sunStrength = Self.lerp([0.00, 0.00, 0.10, 0.62, 1.00], at: t)
         sunElevation = Self.lerp([0.40, 0.38, 0.34, 0.22, 0.13], at: t)

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodWeatherBackground.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodWeatherBackground.swift
@@ -2,11 +2,99 @@
 //  MoodWeatherBackground.swift
 //  WalkWorthy
 //
-//  Full-screen animated weather background driven by mood score (0.0–1.0).
-//  Inspired by Apple Weather app aesthetics with smooth cross-fading scenes.
+//  Full-screen procedural weather background driven by mood score (0.0–1.0).
+//  Apple Weather-style rendering: multi-stop atmospheric sky, sun bloom,
+//  FBM shader cloud decks, and a particle layer for rain and lightning.
+//  Every attribute is a continuous function of the score, so dragging the
+//  slider morphs thunderstorm → rain → overcast → partly cloudy → clear.
 //
 
 import SwiftUI
+
+// MARK: - Weather Parameters
+
+/// Continuous weather description derived from a mood score. Every knob is
+/// interpolated between five keyframes (thunderstorm, rain, overcast,
+/// partly cloudy, clear) so the scene morphs smoothly with the slider.
+struct WeatherParameters {
+    let skyStops: [Color]            // top → horizon
+    let farCloudCoverage: Double
+    let farCloudDarkness: Double
+    let nearCloudCoverage: Double
+    let nearCloudDarkness: Double
+    let cloudVerticalFade: Double    // y fraction where clouds finish fading out
+    let windSpeed: Double            // noise-domain units/sec for the near deck
+    let rainIntensity: Double        // 0–1
+    let lightningIntensity: Double   // 0–1
+    let sunStrength: Double          // 0–1
+    let sunElevation: Double         // y fraction of height (smaller = higher)
+    let hazeOpacity: Double
+
+    init(moodScore: Double) {
+        let t = min(max(moodScore, 0.0), 1.0)
+        skyStops = Self.interpolatedSky(at: t)
+        farCloudCoverage = Self.lerp([0.92, 0.88, 0.85, 0.50, 0.18], at: t)
+        farCloudDarkness = Self.lerp([0.88, 0.66, 0.38, 0.10, 0.02], at: t)
+        nearCloudCoverage = Self.lerp([0.97, 0.90, 0.82, 0.42, 0.10], at: t)
+        nearCloudDarkness = Self.lerp([0.95, 0.72, 0.45, 0.10, 0.00], at: t)
+        cloudVerticalFade = Self.lerp([1.25, 1.15, 1.05, 0.78, 0.55], at: t)
+        windSpeed = Self.lerp([0.040, 0.026, 0.016, 0.012, 0.009], at: t)
+        rainIntensity = Self.lerp([1.00, 0.55, 0.10, 0.00, 0.00], at: t)
+        lightningIntensity = Self.lerp([1.00, 0.00, 0.00, 0.00, 0.00], at: t)
+        sunStrength = Self.lerp([0.00, 0.00, 0.10, 0.62, 1.00], at: t)
+        sunElevation = Self.lerp([0.40, 0.38, 0.34, 0.22, 0.13], at: t)
+        hazeOpacity = Self.lerp([0.06, 0.09, 0.14, 0.18, 0.24], at: t)
+    }
+
+    // MARK: Keyframes
+
+    private static let keyScores: [Double] = [0.0, 0.25, 0.5, 0.75, 1.0]
+
+    /// Sky palettes per keyframe, 5 stops top → horizon (storm, rain,
+    /// overcast, partly cloudy, clear).
+    private static let skyPalettes: [[SIMD3<Double>]] = [
+        [rgb(0x0B0E1A), rgb(0x12182B), rgb(0x1C2438), rgb(0x2A3346), rgb(0x3A4456)],
+        [rgb(0x252E3B), rgb(0x33404F), rgb(0x435162), rgb(0x566375), rgb(0x6B7889)],
+        [rgb(0x57697B), rgb(0x6E7E8E), rgb(0x8493A0), rgb(0x9CA8B2), rgb(0xB4BEC5)],
+        [rgb(0x2566B8), rgb(0x3D7FCB), rgb(0x639DDC), rgb(0x90BEEA), rgb(0xC3DEF5)],
+        [rgb(0x1B66D4), rgb(0x2F7DE0), rgb(0x559CEB), rgb(0x8CC2F4), rgb(0xD9EEFC)],
+    ]
+
+    private static func rgb(_ hex: UInt32) -> SIMD3<Double> {
+        SIMD3(
+            Double((hex >> 16) & 0xFF) / 255.0,
+            Double((hex >> 8) & 0xFF) / 255.0,
+            Double(hex & 0xFF) / 255.0
+        )
+    }
+
+    /// Indices of the keyframes surrounding `t` plus the blend fraction.
+    private static func segment(at t: Double) -> (lower: Int, upper: Int, fraction: Double) {
+        var lower = 0
+        for i in 0..<keyScores.count - 1 where t >= keyScores[i] {
+            lower = i
+        }
+        let upper = min(lower + 1, keyScores.count - 1)
+        let range = keyScores[upper] - keyScores[lower]
+        let fraction = range > 0 ? (t - keyScores[lower]) / range : 0.0
+        return (lower, upper, fraction)
+    }
+
+    private static func lerp(_ values: [Double], at t: Double) -> Double {
+        let s = segment(at: t)
+        return values[s.lower] + (values[s.upper] - values[s.lower]) * s.fraction
+    }
+
+    private static func interpolatedSky(at t: Double) -> [Color] {
+        let s = segment(at: t)
+        return (0..<skyPalettes[s.lower].count).map { stop in
+            let mixed = skyPalettes[s.lower][stop] + (skyPalettes[s.upper][stop] - skyPalettes[s.lower][stop]) * s.fraction
+            return Color(red: mixed.x, green: mixed.y, blue: mixed.z)
+        }
+    }
+}
+
+// MARK: - Background View
 
 struct MoodWeatherBackground: View {
     let moodScore: Double
@@ -16,408 +104,199 @@ struct MoodWeatherBackground: View {
         if isCompact {
             compactOrb
         } else {
-            fullBackground
+            WeatherScene(params: WeatherParameters(moodScore: moodScore))
+                .animation(.easeInOut(duration: 0.5), value: moodScore)
         }
     }
 
-    // MARK: - Full Background
-
-    private var fullBackground: some View {
-        ZStack {
-            skyGradient
-
-            sceneElements
-
-            WeatherParticleSystem(moodScore: moodScore)
-        }
-        .ignoresSafeArea()
-        .animation(.easeInOut(duration: 0.5), value: moodScore)
-    }
-
-    // MARK: - Compact Orb
+    // MARK: Compact Orb
 
     private var compactOrb: some View {
-        let colors = interpolatedColors
+        let params = WeatherParameters(moodScore: moodScore)
+        let top = params.skyStops[0]
+        let bottom = params.skyStops[3]
         return Circle()
             .fill(
                 LinearGradient(
-                    colors: [colors.top, colors.bottom],
+                    colors: [top, bottom],
                     startPoint: .top,
                     endPoint: .bottom
                 )
             )
             .overlay(Circle().stroke(Color.white.opacity(0.3), lineWidth: 1))
-            .shadow(color: colors.bottom.opacity(0.6), radius: scaled(20))
+            .shadow(color: bottom.opacity(0.6), radius: scaled(20))
             .frame(width: scaled(100), height: scaled(100))
             .animation(.easeInOut(duration: 0.5), value: moodScore)
     }
+}
 
-    // MARK: - Sky Gradient
+// MARK: - Weather Scene
 
-    private var skyGradient: some View {
-        let colors = interpolatedColors
-        return LinearGradient(
-            colors: [colors.top, colors.bottom],
+private struct WeatherScene: View {
+    let params: WeatherParameters
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var startDate = Date()
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                sky
+                sun(in: geo.size)
+                cloudDecks(in: geo.size)
+                horizonHaze
+                WeatherParticleSystem(
+                    rainIntensity: params.rainIntensity,
+                    lightningIntensity: params.lightningIntensity
+                )
+            }
+        }
+        .ignoresSafeArea()
+    }
+
+    // MARK: Sky
+
+    private var sky: some View {
+        LinearGradient(
+            colors: params.skyStops,
             startPoint: .top,
             endPoint: .bottom
         )
     }
 
-    // MARK: - Scene Elements
+    // MARK: Sun
 
-    @ViewBuilder
-    private var sceneElements: some View {
-        // Thunderstorm (0.0–0.2)
-        thunderstormScene
-            .opacity(rangeOpacity(low: 0.0, high: 0.2))
+    /// Layered bloom: bright core, warm halo, wide atmospheric glow.
+    /// Sits behind the cloud decks so overcast skies diffuse it.
+    private func sun(in size: CGSize) -> some View {
+        let center = CGPoint(x: size.width * 0.30, y: size.height * params.sunElevation)
+        return ZStack {
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [Color(red: 1.0, green: 0.95, blue: 0.84).opacity(0.50), .clear],
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: scaled(300)
+                    )
+                )
+                .frame(width: scaled(600), height: scaled(600))
+                .position(center)
 
-        // Overcast (0.2–0.4)
-        overcastScene
-            .opacity(rangeOpacity(low: 0.2, high: 0.4))
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [
+                            Color(red: 1.0, green: 0.91, blue: 0.66).opacity(0.85),
+                            Color(red: 1.0, green: 0.84, blue: 0.42).opacity(0.22),
+                            .clear,
+                        ],
+                        center: .center,
+                        startRadius: scaled(8),
+                        endRadius: scaled(130)
+                    )
+                )
+                .frame(width: scaled(260), height: scaled(260))
+                .position(center)
 
-        // Beach (0.4–0.6)
-        beachScene
-            .opacity(rangeOpacity(low: 0.4, high: 0.6))
-
-        // Pleasant (0.6–0.8)
-        pleasantScene
-            .opacity(rangeOpacity(low: 0.6, high: 0.8))
-
-        // Sunny field (0.8–1.0)
-        sunnyFieldScene
-            .opacity(rangeOpacity(low: 0.8, high: 1.0))
+            Circle()
+                .fill(Color.white)
+                .frame(width: scaled(52), height: scaled(52))
+                .blur(radius: scaled(7))
+                .position(center)
+        }
+        .compositingGroup()
+        .blendMode(.screen)
+        .opacity(params.sunStrength)
     }
 
-    // MARK: - Thunderstorm Scene
+    // MARK: Cloud Decks
 
-    private var thunderstormScene: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            let h = geo.size.height
+    /// Two parallax FBM shader layers: a distant slow deck and a nearer,
+    /// faster one. Slow drift only needs 30fps.
+    private func cloudDecks(in size: CGSize) -> some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: reduceMotion)) { timeline in
+            let time = reduceMotion ? 0.0 : timeline.date.timeIntervalSince(startDate)
             ZStack {
-                // Dark jagged clouds
-                RoundedRectangle(cornerRadius: scaled(25))
-                    .fill(Color(hex: 0x2D1B4E).opacity(0.9))
-                    .frame(width: w * 0.5, height: scaled(50))
-                    .offset(x: -w * 0.1, y: h * 0.08)
+                cloudDeck(
+                    size: size,
+                    coverage: params.farCloudCoverage,
+                    darkness: params.farCloudDarkness,
+                    scale: 3.4,
+                    windOffset: time * params.windSpeed * 0.45 + 7.3,
+                    verticalFade: params.cloudVerticalFade
+                )
+                .opacity(0.85)
 
-                RoundedRectangle(cornerRadius: scaled(20))
-                    .fill(Color(hex: 0x3D1C5A).opacity(0.85))
-                    .frame(width: w * 0.4, height: scaled(40))
-                    .offset(x: w * 0.15, y: h * 0.05)
-
-                RoundedRectangle(cornerRadius: scaled(17))
-                    .fill(Color(hex: 0x1A0A2E).opacity(0.8))
-                    .frame(width: w * 0.35, height: scaled(35))
-                    .offset(x: -w * 0.2, y: h * 0.12)
-
-                RoundedRectangle(cornerRadius: scaled(22))
-                    .fill(Color(hex: 0x2D1B4E).opacity(0.75))
-                    .frame(width: w * 0.45, height: scaled(45))
-                    .offset(x: w * 0.25, y: h * 0.1)
-
-                // Rain streaks (static decorative hints — particle system handles animated rain)
-                ForEach(0..<12, id: \.self) { i in
-                    let seedHeight = Self.rainStreakHeights[i % Self.rainStreakHeights.count]
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.white.opacity(0.3))
-                        .frame(width: 1, height: seedHeight)
-                        .offset(
-                            x: CGFloat(i) * (w / 12) - w / 2 + scaled(20),
-                            y: h * 0.3 + CGFloat(i % 3) * scaled(20)
-                        )
-                }
+                cloudDeck(
+                    size: size,
+                    coverage: params.nearCloudCoverage,
+                    darkness: params.nearCloudDarkness,
+                    scale: 2.0,
+                    windOffset: time * params.windSpeed + 23.1,
+                    verticalFade: params.cloudVerticalFade
+                )
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
-    // MARK: - Overcast Scene
-
-    private var overcastScene: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            let h = geo.size.height
-            ZStack {
-                // Heavy grey cloud layers
-                RoundedRectangle(cornerRadius: scaled(27))
-                    .fill(Color(hex: 0x4A5568).opacity(0.85))
-                    .frame(width: w * 0.6, height: scaled(55))
-                    .offset(x: -w * 0.05, y: h * 0.06)
-
-                RoundedRectangle(cornerRadius: scaled(25))
-                    .fill(Color(hex: 0x718096).opacity(0.75))
-                    .frame(width: w * 0.55, height: scaled(50))
-                    .offset(x: w * 0.1, y: h * 0.1)
-
-                RoundedRectangle(cornerRadius: scaled(20))
-                    .fill(Color(hex: 0x4A5568).opacity(0.7))
-                    .frame(width: w * 0.45, height: scaled(40))
-                    .offset(x: -w * 0.15, y: h * 0.14)
-
-                // Lighter drizzle hints
-                ForEach(0..<8, id: \.self) { i in
-                    let seedHeight = Self.drizzleHeights[i % Self.drizzleHeights.count]
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.white.opacity(0.2))
-                        .frame(width: 1, height: seedHeight)
-                        .offset(
-                            x: CGFloat(i) * (w / 8) - w / 2 + scaled(30),
-                            y: h * 0.35 + CGFloat(i % 4) * scaled(15)
-                        )
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+    private func cloudDeck(
+        size: CGSize,
+        coverage: Double,
+        darkness: Double,
+        scale: Double,
+        windOffset: Double,
+        verticalFade: Double
+    ) -> some View {
+        Rectangle()
+            .fill(Color.white)
+            .colorEffect(
+                ShaderLibrary.cloudLayer(
+                    .float2(size),
+                    .float(coverage),
+                    .float(darkness),
+                    .float(scale),
+                    .float(windOffset),
+                    .float(verticalFade)
+                )
+            )
     }
 
-    // MARK: - Beach Scene
+    // MARK: Horizon Haze
 
-    private var beachScene: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            let h = geo.size.height
-            ZStack {
-                // Ocean below horizon
-                Rectangle()
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(hex: 0x2980B9).opacity(0.6),
-                                Color(hex: 0x1A5276).opacity(0.4),
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .frame(height: h * 0.35)
-                    .offset(y: h * 0.325)
-
-                // Gentle wave hint
-                Ellipse()
-                    .fill(Color(hex: 0x2980B9).opacity(0.3))
-                    .frame(width: w * 1.2, height: scaled(30))
-                    .offset(y: h * 0.18)
-
-                Ellipse()
-                    .fill(Color(hex: 0x3498DB).opacity(0.2))
-                    .frame(width: w * 1.1, height: scaled(25))
-                    .offset(y: h * 0.22)
-
-                // Soft sun near horizon
-                Circle()
-                    .fill(
-                        RadialGradient(
-                            colors: [
-                                Color(hex: 0xF6D365).opacity(0.8),
-                                Color(hex: 0xF6D365).opacity(0.0),
-                            ],
-                            center: .center,
-                            startRadius: scaled(15),
-                            endRadius: scaled(60)
-                        )
-                    )
-                    .frame(width: scaled(120), height: scaled(120))
-                    .offset(x: w * 0.15, y: h * 0.08)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-
-    // MARK: - Pleasant Scene
-
-    private var pleasantScene: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            let h = geo.size.height
-            ZStack {
-                // Warm partial sun in upper right
-                Circle()
-                    .fill(
-                        RadialGradient(
-                            colors: [
-                                Color(hex: 0xF6A623).opacity(0.9),
-                                Color(hex: 0xF6A623).opacity(0.0),
-                            ],
-                            center: .center,
-                            startRadius: scaled(20),
-                            endRadius: scaled(80)
-                        )
-                    )
-                    .frame(width: scaled(160), height: scaled(160))
-                    .offset(x: w * 0.25, y: -h * 0.25)
-
-                Circle()
-                    .fill(Color(hex: 0xFDB813).opacity(0.95))
-                    .frame(width: scaled(50), height: scaled(50))
-                    .offset(x: w * 0.25, y: -h * 0.25)
-
-                // Light cloud puffs
-                Ellipse()
-                    .fill(Color.white.opacity(0.5))
-                    .frame(width: scaled(80), height: scaled(30))
-                    .offset(x: -w * 0.2, y: -h * 0.15)
-
-                Ellipse()
-                    .fill(Color.white.opacity(0.4))
-                    .frame(width: scaled(60), height: scaled(25))
-                    .offset(x: w * 0.1, y: -h * 0.1)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-
-    // MARK: - Sunny Field Scene
-
-    private var sunnyFieldScene: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            let h = geo.size.height
-            ZStack {
-                // Bright full sun
-                Circle()
-                    .fill(
-                        RadialGradient(
-                            colors: [
-                                Color.white.opacity(0.9),
-                                Color(hex: 0xFDB813).opacity(0.7),
-                                Color(hex: 0xFDB813).opacity(0.0),
-                            ],
-                            center: .center,
-                            startRadius: scaled(15),
-                            endRadius: scaled(100)
-                        )
-                    )
-                    .frame(width: scaled(200), height: scaled(200))
-                    .offset(x: w * 0.1, y: -h * 0.3)
-
-                Circle()
-                    .fill(Color(hex: 0xFDB813))
-                    .frame(width: scaled(60), height: scaled(60))
-                    .offset(x: w * 0.1, y: -h * 0.3)
-
-                // Rolling green hill silhouette
-                Ellipse()
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(hex: 0x6BCB77).opacity(0.7),
-                                Color(hex: 0x4A9E5C).opacity(0.5),
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .frame(width: w * 1.4, height: h * 0.4)
-                    .offset(y: h * 0.38)
-
-                Ellipse()
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(hex: 0x82D98E).opacity(0.6),
-                                Color(hex: 0x5CB86B).opacity(0.4),
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .frame(width: w * 1.2, height: h * 0.35)
-                    .offset(x: -w * 0.1, y: h * 0.42)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-
-    // MARK: - Static Seeds (avoid CGFloat.random in view body)
-
-    private static let rainStreakHeights: [CGFloat] = [10, 12, 8, 14, 11, 9, 13, 15, 10, 8, 12, 14]
-    private static let drizzleHeights: [CGFloat] = [7, 9, 6, 8, 10, 7, 9, 6]
-
-    // MARK: - Color Interpolation
-
-    private static let paletteStops: [(score: Double, top: (r: Double, g: Double, b: Double), bottom: (r: Double, g: Double, b: Double))] = [
-        (0.0,  (0x1A / 255.0, 0x0A / 255.0, 0x2E / 255.0), (0x3D / 255.0, 0x1C / 255.0, 0x5A / 255.0)),
-        (0.25, (0x2C / 255.0, 0x3E / 255.0, 0x50 / 255.0), (0x4A / 255.0, 0x55 / 255.0, 0x68 / 255.0)),
-        (0.5,  (0x29 / 255.0, 0x80 / 255.0, 0xB9 / 255.0), (0xC9 / 255.0, 0xA9 / 255.0, 0x6E / 255.0)),
-        (0.75, (0xF6 / 255.0, 0xA6 / 255.0, 0x23 / 255.0), (0xF5 / 255.0, 0xCB / 255.0, 0xA7 / 255.0)),
-        (1.0,  (0x87 / 255.0, 0xCE / 255.0, 0xEB / 255.0), (0x98 / 255.0, 0xFB / 255.0, 0x98 / 255.0)),
-    ]
-
-    private var interpolatedColors: (top: Color, bottom: Color) {
-        let score = min(max(moodScore, 0.0), 1.0)
-        let stops = Self.paletteStops
-
-        // Find the two surrounding stops
-        var lowerIdx = 0
-        for i in 0..<stops.count - 1 {
-            if score >= stops[i].score {
-                lowerIdx = i
-            }
-        }
-        let upperIdx = min(lowerIdx + 1, stops.count - 1)
-
-        let lower = stops[lowerIdx]
-        let upper = stops[upperIdx]
-
-        let range = upper.score - lower.score
-        let t = range > 0 ? (score - lower.score) / range : 0.0
-
-        let topR = lower.top.r + (upper.top.r - lower.top.r) * t
-        let topG = lower.top.g + (upper.top.g - lower.top.g) * t
-        let topB = lower.top.b + (upper.top.b - lower.top.b) * t
-
-        let botR = lower.bottom.r + (upper.bottom.r - lower.bottom.r) * t
-        let botG = lower.bottom.g + (upper.bottom.g - lower.bottom.g) * t
-        let botB = lower.bottom.b + (upper.bottom.b - lower.bottom.b) * t
-
-        return (
-            top: Color(red: topR, green: topG, blue: topB),
-            bottom: Color(red: botR, green: botG, blue: botB)
+    /// Atmospheric perspective near the horizon — the depth cue that keeps
+    /// the gradient sky from looking flat.
+    private var horizonHaze: some View {
+        LinearGradient(
+            stops: [
+                .init(color: .clear, location: 0.0),
+                .init(color: .clear, location: 0.55),
+                .init(color: Color(red: 0.95, green: 0.94, blue: 0.90).opacity(params.hazeOpacity), location: 1.0),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
         )
-    }
-
-    // MARK: - Range Opacity
-
-    /// Returns 1.0 when moodScore is fully within [low, high], fading to 0.0 outside with a 0.1 margin.
-    private func rangeOpacity(low: Double, high: Double) -> Double {
-        let score = min(max(moodScore, 0.0), 1.0)
-        let fadeMargin = 0.1
-        let center = (low + high) / 2.0
-        let halfWidth = (high - low) / 2.0
-
-        let distance = abs(score - center)
-        if distance <= halfWidth {
-            return 1.0
-        } else if distance <= halfWidth + fadeMargin {
-            return 1.0 - (distance - halfWidth) / fadeMargin
-        } else {
-            return 0.0
-        }
-    }
-}
-
-// MARK: - Color Hex Extension
-
-private extension Color {
-    init(hex: UInt32) {
-        let r = Double((hex >> 16) & 0xFF) / 255.0
-        let g = Double((hex >> 8) & 0xFF) / 255.0
-        let b = Double(hex & 0xFF) / 255.0
-        self.init(red: r, green: g, blue: b)
     }
 }
 
 #Preview("Full - Thunderstorm") {
-    MoodWeatherBackground(moodScore: 0.1)
+    MoodWeatherBackground(moodScore: 0.0)
 }
 
-#Preview("Full - Beach") {
+#Preview("Full - Rain") {
+    MoodWeatherBackground(moodScore: 0.25)
+}
+
+#Preview("Full - Overcast") {
     MoodWeatherBackground(moodScore: 0.5)
 }
 
+#Preview("Full - Partly Cloudy") {
+    MoodWeatherBackground(moodScore: 0.75)
+}
+
 #Preview("Full - Sunny") {
-    MoodWeatherBackground(moodScore: 0.9)
+    MoodWeatherBackground(moodScore: 1.0)
 }
 
 #Preview("Compact Orb") {

--- a/WalkWorthy/WalkWorthy/UI/Mood/WeatherParticleSystem.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/WeatherParticleSystem.swift
@@ -2,296 +2,241 @@
 //  WeatherParticleSystem.swift
 //  WalkWorthy
 //
-//  TimelineView + Canvas particle system for mood weather effects.
-//  Rain, lightning, waves, grass, and clouds driven by moodScore (0.0–1.0).
+//  TimelineView + Canvas precipitation layer for the mood weather scene.
+//  Depth-layered wind-blown rain and branched lightning with cloud
+//  illumination, driven by intensities from WeatherParameters.
 //
 
 import SwiftUI
 
 struct WeatherParticleSystem: View {
-    let moodScore: Double
+    let rainIntensity: Double       // 0–1
+    let lightningIntensity: Double  // 0–1
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        TimelineView(.animation) { timeline in
+        TimelineView(.animation(paused: reduceMotion)) { timeline in
             Canvas { context, size in
-                let time = timeline.date.timeIntervalSinceReferenceDate
+                // Frozen timestamp under Reduce Motion renders one static
+                // frame — rain streaks read like a photograph.
+                let time = reduceMotion ? 41.7 : timeline.date.timeIntervalSinceReferenceDate
 
-                drawRain(context: &context, size: size, time: time)
-                drawLightning(context: &context, size: size, time: time)
-                drawBeachWaves(context: &context, size: size, time: time)
-                drawClouds(context: &context, size: size, time: time)
-                drawGrass(context: &context, size: size, time: time)
+                if rainIntensity > 0.01 {
+                    drawRain(context: context, size: size, time: time)
+                }
+                // No lightning under Reduce Motion — flashing is also an
+                // accessibility concern, not just a motion one.
+                if lightningIntensity > 0.01 && !reduceMotion {
+                    drawLightning(context: context, size: size, time: time)
+                }
             }
         }
         .allowsHitTesting(false)
     }
 
-    // MARK: - Rain (moodScore 0.0–0.5, intensity peaks at 0.0)
+    // MARK: - Rain
 
-    private func drawRain(context: inout GraphicsContext, size: CGSize, time: Double) {
-        guard moodScore < 0.5 else { return }
-
-        // Intensity: 1.0 at score 0.0, fading to 0.0 at score 0.5
-        let intensity = max(0, 1.0 - moodScore / 0.5)
-        let particleCount = Int(60.0 * intensity)
-
-        for i in 0..<particleCount {
-            let seed = Self.rainSeeds[i % Self.rainSeeds.count]
-
-            // Horizontal position: fixed per particle, scattered across width
-            let x = seed.xFraction * size.width
-
-            // Vertical position: falls at varying speed, wraps around
-            let speed = seed.speed  // 200–400 pt/sec
-            let totalFall = time * speed + seed.yOffset * size.height
-            let y = totalFall.truncatingRemainder(dividingBy: Double(size.height))
-
-            let height = seed.length  // 8–15pt
-
-            var path = Path()
-            path.move(to: CGPoint(x: x, y: y))
-            path.addLine(to: CGPoint(x: x, y: y + height))
-
-            context.stroke(
-                path,
-                with: .color(.white.opacity(0.4 * intensity)),
-                lineWidth: 1
-            )
-        }
+    /// Three depth layers: far = slow/short/faint, near = fast/long/bold.
+    /// A shared wind angle makes the layers read as one storm.
+    private struct RainLayer {
+        let dropCount: Int
+        let minSpeed: Double
+        let maxSpeed: Double
+        let minLength: Double
+        let maxLength: Double
+        let lineWidth: CGFloat
+        let opacity: Double
     }
 
-    // MARK: - Lightning (moodScore 0.0–0.2)
+    private static let rainLayers: [RainLayer] = [
+        RainLayer(dropCount: 44, minSpeed: 320, maxSpeed: 430, minLength: 11, maxLength: 17, lineWidth: 0.8, opacity: 0.20),
+        RainLayer(dropCount: 36, minSpeed: 470, maxSpeed: 600, minLength: 18, maxLength: 26, lineWidth: 1.1, opacity: 0.32),
+        RainLayer(dropCount: 26, minSpeed: 640, maxSpeed: 820, minLength: 28, maxLength: 42, lineWidth: 1.6, opacity: 0.45),
+    ]
 
-    private func drawLightning(context: inout GraphicsContext, size: CGSize, time: Double) {
-        guard moodScore < 0.2 else { return }
+    /// Rain leans ~10° with the wind; streaks are drawn along their velocity.
+    private static let windSlope = 0.18
 
-        let intensity = max(0, 1.0 - moodScore / 0.2)
+    private func drawRain(context: GraphicsContext, size: CGSize, time: Double) {
+        let rainColor = Color(red: 0.78, green: 0.85, blue: 0.95)
 
-        // Flash cycle: bolt appears every ~3 seconds, visible for 0.15s
-        let cycleLength = 3.0
-        let flashDuration = 0.15
-        let phase = time.truncatingRemainder(dividingBy: cycleLength)
+        for (layerIndex, layer) in Self.rainLayers.enumerated() {
+            // sqrt keeps some far-layer depth alive at drizzle intensities.
+            let activeCount = Int(Double(layer.dropCount) * rainIntensity.squareRoot())
+            guard activeCount > 0 else { continue }
+            let opacity = layer.opacity * (0.6 + 0.4 * rainIntensity)
 
-        guard phase < flashDuration else { return }
+            for i in 0..<activeCount {
+                let seed = Self.dropSeeds[(i &+ layerIndex &* 17) % Self.dropSeeds.count]
+                let speed = scaled(layer.minSpeed + (layer.maxSpeed - layer.minSpeed) * seed.speedUnit)
+                let length = scaled(layer.minLength + (layer.maxLength - layer.minLength) * seed.lengthUnit)
 
-        // Brief screen flash
-        let flashRect = Path(CGRect(origin: .zero, size: size))
-        context.fill(flashRect, with: .color(.white.opacity(0.15 * intensity)))
+                // Fall and wrap within a band slightly taller than the view.
+                let band = size.height + length * 2
+                let travel = time * speed + seed.travelOffset * band
+                let y = travel.truncatingRemainder(dividingBy: band) - length
 
-        // Jagged bolt from near top-center downward
-        let boltStartX = size.width * 0.45
-        let boltStartY = size.height * 0.05
-        let segments = 6
-        let segmentHeight = scaled(30.0)
+                // Drift sideways with the wind as the drop falls; wrap on x.
+                let xBase = (seed.xFraction + Double(layerIndex) * 0.37) * size.width
+                let x = (xBase + y * Self.windSlope).truncatingRemainder(dividingBy: size.width)
+                let xWrapped = x < 0 ? x + size.width : x
 
-        var path = Path()
-        path.move(to: CGPoint(x: boltStartX, y: boltStartY))
+                let head = CGPoint(x: xWrapped, y: y)
+                let tail = CGPoint(x: xWrapped + Self.windSlope * length, y: y + length)
 
-        var currentX = boltStartX
-        var currentY = boltStartY
+                var path = Path()
+                path.move(to: head)
+                path.addLine(to: tail)
 
-        for seg in 0..<segments {
-            // Alternate zig-zag direction using deterministic offset
-            let zigDirection: Double = seg.isMultiple(of: 2) ? 1.0 : -1.0
-            let xOffset = zigDirection * Double(scaled(15) + scaled(CGFloat((seg * 7) % 20)))
-            currentX += xOffset
-            currentY += segmentHeight
-            path.addLine(to: CGPoint(x: currentX, y: currentY))
-        }
-
-        context.stroke(
-            path,
-            with: .color(Color(red: 1.0, green: 1.0, blue: 0.8).opacity(0.9 * intensity)),
-            lineWidth: 2
-        )
-    }
-
-    // MARK: - Beach Waves (moodScore 0.4–0.6)
-
-    private func drawBeachWaves(context: inout GraphicsContext, size: CGSize, time: Double) {
-        guard moodScore >= 0.4 && moodScore <= 0.6 else { return }
-
-        // Opacity peaks at 0.5
-        let proximity = 1.0 - abs(moodScore - 0.5) / 0.1
-        let opacity = max(0, min(1, proximity)) * 0.3
-
-        let waveCount = 3
-        for wave in 0..<waveCount {
-            let baseY = size.height * (0.65 + Double(wave) * 0.06)
-            let amplitude = 6.0 - Double(wave) * 1.5
-            let phaseOffset = time * 0.5 + Double(wave) * 1.2
-
-            var path = Path()
-            let steps = 40
-            for step in 0...steps {
-                let fraction = Double(step) / Double(steps)
-                let x = fraction * size.width
-                let y = baseY + sin(fraction * .pi * 4 + phaseOffset) * amplitude
-
-                if step == 0 {
-                    path.move(to: CGPoint(x: x, y: y))
+                let style = StrokeStyle(lineWidth: scaled(layer.lineWidth), lineCap: .round)
+                if layerIndex == 0 {
+                    // Far layer: solid strokes — cheaper, and the fade is
+                    // invisible at this scale anyway.
+                    context.stroke(path, with: .color(rainColor.opacity(opacity)), style: style)
                 } else {
-                    path.addLine(to: CGPoint(x: x, y: y))
+                    // Streak fades along its length — reads as motion blur,
+                    // brightest at the falling edge.
+                    context.stroke(
+                        path,
+                        with: .linearGradient(
+                            Gradient(colors: [rainColor.opacity(0), rainColor.opacity(opacity)]),
+                            startPoint: head,
+                            endPoint: tail
+                        ),
+                        style: style
+                    )
                 }
             }
-
-            context.stroke(
-                path,
-                with: .color(Color(red: 0.2, green: 0.7, blue: 0.8).opacity(opacity)),
-                lineWidth: 1.5
-            )
         }
     }
 
-    // MARK: - Cloud Drift (moodScore 0.5–1.0)
+    // MARK: - Lightning
 
-    private func drawClouds(context: inout GraphicsContext, size: CGSize, time: Double) {
-        guard moodScore >= 0.5 else { return }
+    private func drawLightning(context: GraphicsContext, size: CGSize, time: Double) {
+        let cycleLength = 4.0
+        let cycle = (time / cycleLength).rounded(.down)
+        // Roughly 1 in 5 cycles stays dark so strikes feel irregular.
+        guard Self.hash(cycle * 17.31) < 0.8 else { return }
 
-        // Opacity: 20% at neutral, 60% at very pleasant
-        let t = min(max((moodScore - 0.5) / 0.5, 0), 1)
-        let baseOpacity = 0.2 + t * 0.4
+        let phase = time - cycle * cycleLength
+        let brightness = Self.flickerEnvelope(phase) * lightningIntensity
+        guard brightness > 0.01 else { return }
 
-        for i in 0..<3 {
-            let seed = Self.cloudSeeds[i]
+        let origin = CGPoint(
+            x: (0.22 + Self.hash(cycle * 31.7 + 3.1) * 0.56) * size.width,
+            y: size.height * 0.04
+        )
 
-            // Drift slowly rightward, wrap
-            let speed = seed.speed  // ~15–25 pt/sec
-            let totalDrift = time * speed + seed.startX * size.width
-            let x = totalDrift.truncatingRemainder(dividingBy: size.width + scaled(120)) - scaled(60)
+        // Cloud illumination — a bloom centered on the strike origin rather
+        // than a flat full-screen wash.
+        context.fill(
+            Path(CGRect(origin: .zero, size: size)),
+            with: .radialGradient(
+                Gradient(colors: [Color.white.opacity(0.30 * brightness), .clear]),
+                center: origin,
+                startRadius: 0,
+                endRadius: size.width * 0.9
+            )
+        )
 
-            let y = seed.yFraction * size.height * 0.4
+        // The bolt itself only shows during the bright pulses.
+        guard phase < 0.26, brightness > 0.3 * lightningIntensity else { return }
 
-            // Cloud = overlapping circles
-            let r1 = seed.radius1
-            let r2 = seed.radius2
-            let r3 = seed.radius3
+        let bolt = Self.boltPath(cycle: cycle, origin: origin, size: size)
+        let boltColor = Color(red: 1.0, green: 1.0, blue: 0.88)
 
-            let cloudColor = Color.white.opacity(baseOpacity)
+        var wideGlow = context
+        wideGlow.addFilter(.blur(radius: scaled(7)))
+        wideGlow.stroke(bolt, with: .color(boltColor.opacity(0.7 * brightness)), lineWidth: scaled(6))
 
-            let circle1 = Path(ellipseIn: CGRect(x: x - r1, y: y - r1, width: r1 * 2, height: r1 * 2))
-            let circle2 = Path(ellipseIn: CGRect(x: x + r1 * 0.7 - r2, y: y - r2 * 0.5 - r2, width: r2 * 2, height: r2 * 2))
-            let circle3 = Path(ellipseIn: CGRect(x: x + r1 * 1.2 - r3, y: y - r3, width: r3 * 2, height: r3 * 2))
+        var innerGlow = context
+        innerGlow.addFilter(.blur(radius: scaled(2.5)))
+        innerGlow.stroke(bolt, with: .color(boltColor.opacity(0.9 * brightness)), lineWidth: scaled(2.6))
 
-            context.fill(circle1, with: .color(cloudColor))
-            context.fill(circle2, with: .color(cloudColor))
-            context.fill(circle3, with: .color(cloudColor))
+        context.stroke(bolt, with: .color(Color.white.opacity(brightness)), lineWidth: scaled(1.1))
+    }
+
+    /// Real lightning strobes: bright leader, brief dropout, a second return
+    /// stroke, then a slow afterglow decay over ~half a second.
+    private static func flickerEnvelope(_ phase: Double) -> Double {
+        switch phase {
+        case ..<0.07: return 1.0
+        case ..<0.12: return 0.25
+        case ..<0.20: return 0.85
+        case ..<0.55: return 0.85 * (1.0 - (phase - 0.20) / 0.35)
+        default: return 0.0
         }
     }
 
-    // MARK: - Grass Blades (moodScore 0.7–1.0, intensity peaks at 1.0)
+    /// Jagged main trunk with two short branches. Geometry is a pure
+    /// function of the cycle index, so each strike looks different but a
+    /// single strike is stable across frames.
+    private static func boltPath(cycle: Double, origin: CGPoint, size: CGSize) -> Path {
+        var path = Path()
+        let segments = 8
+        let segmentDrop = size.height * 0.5 / CGFloat(segments)
 
-    private func drawGrass(context: inout GraphicsContext, size: CGSize, time: Double) {
-        guard moodScore >= 0.7 else { return }
+        var point = origin
+        path.move(to: point)
+        var trunkPoints: [CGPoint] = [point]
 
-        let intensity = min(max((moodScore - 0.7) / 0.3, 0), 1)
-        let bladeCount = Int(40.0 * intensity)
-
-        for i in 0..<bladeCount {
-            let seed = Self.grassSeeds[i % Self.grassSeeds.count]
-
-            let baseX = seed.xFraction * size.width
-            let baseY = size.height
-            let height = seed.height  // 20–40pt
-
-            // Sway with sine wave
-            let swayAmount = scaled(8.0) * intensity
-            let sway = sin(time * 1.5 + seed.phaseOffset) * swayAmount
-
-            let tipX = baseX + sway
-            let tipY = baseY - height
-
-            // Control point for curve
-            let ctrlX = baseX + sway * 0.5
-            let ctrlY = baseY - height * 0.6
-
-            var path = Path()
-            path.move(to: CGPoint(x: baseX, y: baseY))
-            path.addQuadCurve(
-                to: CGPoint(x: tipX, y: tipY),
-                control: CGPoint(x: ctrlX, y: ctrlY)
-            )
-
-            let greenValue = 0.5 + seed.greenVariation * 0.3
-            context.stroke(
-                path,
-                with: .color(Color(red: 0.2, green: greenValue, blue: 0.15).opacity(0.7 * intensity)),
-                lineWidth: 1.5
-            )
+        for seg in 0..<segments {
+            let jitter = hash(cycle * 7.7 + Double(seg) * 13.3) - 0.5
+            point.x += jitter * scaled(52)
+            point.y += segmentDrop * (0.85 + 0.3 * hash(cycle * 3.3 + Double(seg) * 5.1))
+            path.addLine(to: point)
+            trunkPoints.append(point)
         }
+
+        for (branchIndex, sourceSegment) in [2, 5].enumerated() {
+            var branchPoint = trunkPoints[sourceSegment]
+            path.move(to: branchPoint)
+            let direction: CGFloat = hash(cycle * 11.1 + Double(branchIndex)) < 0.5 ? -1 : 1
+            for seg in 0..<3 {
+                let jitter = hash(cycle * 9.4 + Double(branchIndex * 10 + seg) * 3.7)
+                branchPoint.x += direction * scaled(14 + 18 * jitter)
+                branchPoint.y += segmentDrop * (0.5 + 0.4 * jitter)
+                path.addLine(to: branchPoint)
+            }
+        }
+
+        return path
     }
 
     // MARK: - Deterministic Seeds
 
-    /// Fixed seeds so particles don't jump on re-render.
-    private struct RainSeed {
+    private struct DropSeed {
         let xFraction: Double
-        let yOffset: Double
-        let speed: Double
-        let length: Double
+        let travelOffset: Double
+        let speedUnit: Double
+        let lengthUnit: Double
     }
 
-    private struct CloudSeed {
-        let startX: Double
-        let yFraction: Double
-        let speed: Double
-        let radius1: Double
-        let radius2: Double
-        let radius3: Double
+    /// Fixed seeds so drops don't jump between frames.
+    private static let dropSeeds: [DropSeed] = (0..<44).map { i in
+        let n = Double(i)
+        return DropSeed(
+            xFraction: hash(n * 12.9898),
+            travelOffset: hash(n * 78.233 + 1.0),
+            speedUnit: hash(n * 37.719 + 2.0),
+            lengthUnit: hash(n * 93.989 + 3.0)
+        )
     }
 
-    private struct GrassSeed {
-        let xFraction: Double
-        let height: Double
-        let phaseOffset: Double
-        let greenVariation: Double
+    /// Deterministic hash → [0, 1). Same trick as the shader's noise hash.
+    private static func hash(_ n: Double) -> Double {
+        let s = sin(n + 311.7) * 43758.5453
+        return s - s.rounded(.down)
     }
-
-    // Pre-computed deterministic seeds — avoids random in render loop
-    private static let rainSeeds: [RainSeed] = {
-        var seeds: [RainSeed] = []
-        for i in 0..<60 {
-            let hash = Double(((i &* 2654435761) & 0xFFFF))  // simple hash
-            let xFrac = Double(i) / 60.0 + (hash / 65535.0) * 0.015
-            let yOff = (hash.truncatingRemainder(dividingBy: 100)) / 100.0
-            let speed = scaled(200.0) + (hash.truncatingRemainder(dividingBy: scaled(200)))
-            let length = scaled(8.0) + (hash.truncatingRemainder(dividingBy: scaled(7)))
-            seeds.append(RainSeed(xFraction: xFrac, yOffset: yOff, speed: speed, length: length))
-        }
-        return seeds
-    }()
-
-    private static let cloudSeeds: [CloudSeed] = [
-        CloudSeed(startX: 0.1, yFraction: 0.15, speed: scaled(15), radius1: scaled(20), radius2: scaled(16), radius3: scaled(14)),
-        CloudSeed(startX: 0.5, yFraction: 0.25, speed: scaled(20), radius1: scaled(25), radius2: scaled(18), radius3: scaled(20)),
-        CloudSeed(startX: 0.8, yFraction: 0.10, speed: scaled(12), radius1: scaled(18), radius2: scaled(22), radius3: scaled(15)),
-    ]
-
-    private static let grassSeeds: [GrassSeed] = {
-        var seeds: [GrassSeed] = []
-        for i in 0..<40 {
-            let hash = Double(((i &* 2654435761) & 0xFFFF))
-            let xFrac = Double(i) / 40.0 + (hash / 65535.0) * 0.02
-            let height = scaled(20.0) + (hash.truncatingRemainder(dividingBy: scaled(20)))
-            let phase = Double(i) * 0.7 + (hash / 65535.0) * 2.0
-            let greenVar = (hash.truncatingRemainder(dividingBy: 100)) / 100.0
-            seeds.append(GrassSeed(xFraction: xFrac, height: height, phaseOffset: phase, greenVariation: greenVar))
-        }
-        return seeds
-    }()
 }
 
-#Preview("Rain & Lightning") {
-    WeatherParticleSystem(moodScore: 0.1)
-        .background(Color(red: 0.1, green: 0.04, blue: 0.18))
+#Preview("Storm") {
+    WeatherParticleSystem(rainIntensity: 1.0, lightningIntensity: 1.0)
+        .background(Color(red: 0.06, green: 0.07, blue: 0.12))
 }
 
-#Preview("Beach Waves") {
-    WeatherParticleSystem(moodScore: 0.5)
-        .background(Color(red: 0.16, green: 0.5, blue: 0.72))
-}
-
-#Preview("Grass & Clouds") {
-    WeatherParticleSystem(moodScore: 0.9)
-        .background(Color(red: 0.53, green: 0.81, blue: 0.92))
+#Preview("Light Rain") {
+    WeatherParticleSystem(rainIntensity: 0.4, lightningIntensity: 0.0)
+        .background(Color(red: 0.25, green: 0.30, blue: 0.36))
 }

--- a/WalkWorthy/WalkWorthy/UI/Mood/WeatherShaders.metal
+++ b/WalkWorthy/WalkWorthy/UI/Mood/WeatherShaders.metal
@@ -1,0 +1,83 @@
+//
+//  WeatherShaders.metal
+//  WalkWorthy
+//
+//  Procedural cloud rendering for the mood weather background.
+//  Domain-warped FBM value noise in the style of Apple Weather's
+//  procedural skies, exposed to SwiftUI via `colorEffect`.
+//
+
+#include <metal_stdlib>
+using namespace metal;
+
+// Deterministic 2D hash → [0, 1)
+static inline float hash21(float2 p) {
+    p = fract(p * float2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+// Bilinear value noise with smoothstep interpolation
+static inline float valueNoise(float2 p) {
+    float2 i = floor(p);
+    float2 f = fract(p);
+    float2 u = f * f * (3.0 - 2.0 * f);
+
+    float a = hash21(i);
+    float b = hash21(i + float2(1.0, 0.0));
+    float c = hash21(i + float2(0.0, 1.0));
+    float d = hash21(i + float2(1.0, 1.0));
+
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+// 5-octave fractal Brownian motion, rotated per octave to hide grid artifacts
+static inline float fbm(float2 p) {
+    float value = 0.0;
+    float amplitude = 0.5;
+    const float2x2 rotate = float2x2(0.8, 0.6, -0.6, 0.8);
+    for (int i = 0; i < 5; i++) {
+        value += amplitude * valueNoise(p);
+        p = rotate * p * 2.02;
+        amplitude *= 0.5;
+    }
+    return value;  // ≈ [0, 1]
+}
+
+/// One cloud deck. Returns premultiplied RGBA so clear sky stays transparent.
+///
+///  - coverage:     0 = clear sky, 1 = full cover
+///  - darkness:     0 = sunlit white cumulus, 1 = near-black storm cell
+///  - scale:        noise domain scale (larger = smaller, busier clouds)
+///  - windOffset:   horizontal drift in noise-domain units (time × speed, computed on CPU)
+///  - verticalFade: fraction of view height at which the deck has fully faded out
+[[ stitchable ]] half4 cloudLayer(float2 position, half4 color, float2 size,
+                                  float coverage, float darkness, float scale,
+                                  float windOffset, float verticalFade) {
+    float2 uv = position / size.x;
+    float2 p = uv * scale + float2(windOffset, 0.0);
+
+    // Domain warp: sampling fbm through a second fbm gives billowy,
+    // organic cloud edges instead of uniform noise blobs.
+    float warp = fbm(p + float2(windOffset * 0.35, 0.0));
+    float n = fbm(p + float2(warp * 0.9, warp * 0.4));
+
+    // Coverage slides the density threshold through the noise field.
+    float threshold = mix(0.78, 0.18, clamp(coverage, 0.0, 1.0));
+    float density = smoothstep(threshold, threshold + 0.32, n);
+
+    // Fade toward the horizon so the deck reads as overhead sky.
+    float yFrac = position.y / size.y;
+    density *= 1.0 - smoothstep(verticalFade * 0.55, verticalFade, yFrac);
+
+    // Dense cores shade darker while edges stay lit — fakes top-lit volume.
+    // The lit tone falls off steeply with darkness: storm-cloud highlights
+    // are slate-gray with a cold blue cast, not light gray.
+    float core = smoothstep(threshold + 0.05, threshold + 0.55, n);
+    float3 litColor  = mix(float3(1.0, 1.0, 1.0), float3(0.36, 0.38, 0.47), darkness * darkness * 0.4 + darkness * 0.6);
+    float3 coreColor = mix(float3(0.82, 0.84, 0.88), float3(0.09, 0.09, 0.14), darkness);
+    float3 cloud = mix(litColor, coreColor, core * (0.45 + 0.55 * darkness));
+
+    float alpha = density * (0.85 + 0.15 * darkness);
+    return half4(half3(float3(cloud * alpha)), half(alpha));
+}

--- a/WalkWorthy/WalkWorthy/UI/Mood/WeatherShaders.metal
+++ b/WalkWorthy/WalkWorthy/UI/Mood/WeatherShaders.metal
@@ -55,11 +55,17 @@ static inline float fbm(float2 p) {
                                   float coverage, float darkness, float scale,
                                   float windOffset, float verticalFade) {
     float2 uv = position / size.x;
-    float2 p = uv * scale + float2(windOffset, 0.0);
+    // Subtracting the offset moves the pattern rightward on screen — the
+    // same direction the rain streaks lean, so the whole scene shares one
+    // wind direction.
+    float2 p = uv * scale - float2(windOffset, 0.0);
 
     // Domain warp: sampling fbm through a second fbm gives billowy,
-    // organic cloud edges instead of uniform noise blobs.
-    float warp = fbm(p + float2(windOffset * 0.35, 0.0));
+    // organic cloud edges instead of uniform noise blobs. The warp field
+    // drifts at a different rate than the clouds (and slightly vertically),
+    // so shapes churn and evolve as the wind carries them instead of
+    // sliding past like a flat image.
+    float warp = fbm(p + float2(windOffset * 0.35, windOffset * 0.13));
     float n = fbm(p + float2(warp * 0.9, warp * 0.4));
 
     // Coverage slides the density threshold through the noise field.


### PR DESCRIPTION
## Summary

Replaces the cartoony SwiftUI-shape scenery on the mood check-in slider with a **procedural GPU weather renderer** in the style of the Apple Weather app. As the slider moves from Very Unpleasant to Very Pleasant, the scene morphs continuously: **thunderstorm → rain → overcast → partly cloudy → clear sunny day** — no hard scene swaps, every attribute is a smooth function of the mood score.

Supersedes the earlier looping-video approach (`feat/photoreal-mood-scenery`), which was blocked on generating MP4 assets. This needs zero assets.

## How it works

- **`WeatherShaders.metal` (new)** — `[[stitchable]]` fragment shader for SwiftUI `colorEffect`: 5-octave domain-warped FBM value noise renders soft volumetric cloud fields. Coverage, darkness, scale, wind drift, and vertical fade are uniforms driven by the mood score. Two instances at different scales/speeds form a near/far parallax cloud deck.
- **`MoodWeatherBackground.swift` (rewritten)** — new `WeatherParameters` struct interpolates all knobs across 5 keyframes. Layer stack: 5-stop atmospheric sky gradient → layered sun bloom (screen blend) → dual shader cloud decks (30fps TimelineView) → horizon haze → particles. The compact-orb API used by the other wizard steps is unchanged.
- **`WeatherParticleSystem.swift` (overhauled)** — rain in 3 depth layers with a shared 10° wind lean and motion-blur gradient streaks; lightning on a 4s cycle with deterministic per-cycle hashing (position/shape/skipped cycles), double-flicker strobe envelope, branched bolt drawn with two blur passes + sharp core, and radial cloud illumination instead of a flat screen flash. Beach waves/grass removed.
- **Accessibility** — Reduce Motion freezes cloud drift and rain (static frame) and disables lightning flashes entirely.

## Verification

- `xcodebuild` BUILD SUCCEEDED (iPhone 17 Pro, iOS 26 sim). Note: required the new separate Metal Toolchain component (`xcodebuild -downloadComponent MetalToolchain`) — CI is unaffected since it only deploys the backend.
- Screenshots captured at mood scores 0.0 / 0.25 / 0.5 / 0.75 / 1.0 — five clearly differentiated, smoothly related scenes.
- Lightning verified by recording 10s of video and ranking frames by luminance: two strikes exactly two 4s-cycles apart (one randomly skipped cycle in between, as designed); extracted frames show the branched glowing bolt.
- Compact orb verified on the emotion-tags step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)