### PR TITLE
fix: compose button clipping + chip mid-word wrapping on non-Pro-Max iPhones

### DIFF
--- a/WalkWorthy/WalkWorthy/UI/Auth/SignInFormView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Auth/SignInFormView.swift
@@ -53,7 +53,7 @@ struct SignInFormView: View {
                 legalConsentText
             }
         }
-        .padding(.horizontal, scaled(24))
+        .padding(.horizontal, scaled(12))
         .padding(.vertical, scaled(16))
         .task {
             // Wait for SwiftUI to settle keyboard/focus before requesting email focus.

--- a/WalkWorthy/WalkWorthy/UI/Components/DynamicBackgroundView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Components/DynamicBackgroundView.swift
@@ -17,10 +17,18 @@ struct DynamicBackgroundView: View {
             theme.backdrop
                 .ignoresSafeArea()
 
-            Image(theme.timeOfDay.imageName)
-                .resizable()
-                .scaledToFill()
+            // The fill image lives in an overlay so its cropped-off width never
+            // leaks into layout: a bare `.scaledToFill().frame(height:)` reports
+            // width = height × aspect (wider than the screen), which inflates
+            // the enclosing ZStack and pushes trailing-aligned siblings —
+            // like Journal's compose button — off the screen edge.
+            Color.clear
                 .frame(height: scaled(280))
+                .overlay(
+                    Image(theme.timeOfDay.imageName)
+                        .resizable()
+                        .scaledToFill()
+                )
                 .clipped()
                 .overlay(
                     LinearGradient(

--- a/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Home/HomeView.swift
@@ -54,7 +54,7 @@ struct HomeView: View {
                     // Quick actions
                     quickActions
                 }
-                .padding(.horizontal, scaled(24))
+                .padding(.horizontal, scaled(12))
                 .padding(.top, scaled(8))
                 .padding(.bottom, scaled(120))
             }

--- a/WalkWorthy/WalkWorthy/UI/Journal/JournalEditorView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/JournalEditorView.swift
@@ -101,7 +101,7 @@ struct JournalEditorView: View {
                             .scrollContentBackground(.hidden)
                     }
                 }
-                .padding(.horizontal, scaled(32))
+                .padding(.horizontal, scaled(16))
                 .padding(.top, scaled(24))
                 .padding(.bottom, scaled(16))
             }

--- a/WalkWorthy/WalkWorthy/UI/Journal/JournalListView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Journal/JournalListView.swift
@@ -103,7 +103,7 @@ private struct JournalListContent: View {
                     .background(Circle().fill(Color.accentColor))
                     .shadow(radius: scaled(4), y: scaled(2))
             }
-            .padding(.trailing, scaled(20))
+            .padding(.trailing, scaled(10))
             .padding(.bottom, scaled(24))
             .accessibilityLabel("New note")
         }

--- a/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/CinematicTransitionView.swift
@@ -80,7 +80,7 @@ struct CinematicTransitionView: View {
                     if let result = response {
                         ScrollView {
                             MoodResponseContent(response: result, onDismiss: onDone)
-                                .padding(.horizontal, scaled(16))
+                                .padding(.horizontal, scaled(8))
                                 .padding(.top, scaled(16))
                                 .padding(.bottom, scaled(40))
                                 .frame(maxWidth: .infinity)

--- a/WalkWorthy/WalkWorthy/UI/Mood/EmotionTagsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/EmotionTagsView.swift
@@ -144,6 +144,11 @@ struct ChipButton: View {
             Text(label)
                 .font(.subheadline)
                 .multilineTextAlignment(.center)
+                // Single-line pills: long labels ("Overwhelmed", "Disappointed")
+                // hyphen-break mid-word inside the grid cell on 402pt-wide
+                // iPhones. Shrink slightly instead of wrapping.
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
                 .padding(.horizontal, scaled(14))
                 .padding(.vertical, scaled(8))
                 .frame(minWidth: 0)

--- a/WalkWorthy/WalkWorthy/UI/Mood/EmotionTagsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/EmotionTagsView.swift
@@ -23,7 +23,7 @@ struct EmotionTagsView: View {
                     .font(.title3.weight(.semibold))
                     .foregroundColor(.white)
             }
-            .padding(.horizontal, scaled(42))
+            .padding(.horizontal, scaled(21))
             .padding(.top, scaled(20))
 
             VStack(spacing: 0) {
@@ -62,7 +62,7 @@ struct EmotionTagsView: View {
                                 }
                             }
                         }
-                        .padding(.horizontal, scaled(24))
+                        .padding(.horizontal, scaled(12))
                     }
                     .padding(.bottom, scaled(24))
                 }
@@ -78,7 +78,7 @@ struct EmotionTagsView: View {
                         .background(TimeOfDayTheme.current.accent)
                         .cornerRadius(scaled(30))
                 }
-                .padding(.horizontal, scaled(24))
+                .padding(.horizontal, scaled(12))
                 .padding(.bottom, scaled(40))
             }
         }

--- a/WalkWorthy/WalkWorthy/UI/Mood/ImpactCategoriesView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/ImpactCategoriesView.swift
@@ -31,7 +31,7 @@ struct ImpactCategoriesView: View {
                     .font(.title3.weight(.semibold))
                     .foregroundColor(.white)
             }
-            .padding(.horizontal, scaled(42))
+            .padding(.horizontal, scaled(21))
             .padding(.top, scaled(20))
 
             VStack(spacing: 0) {
@@ -70,7 +70,7 @@ struct ImpactCategoriesView: View {
                                 }
                             }
                         }
-                        .padding(.horizontal, scaled(24))
+                        .padding(.horizontal, scaled(12))
                     }
                     .padding(.bottom, scaled(24))
                 }
@@ -86,7 +86,7 @@ struct ImpactCategoriesView: View {
                         .background(TimeOfDayTheme.current.accent)
                         .cornerRadius(scaled(30))
                 }
-                .padding(.horizontal, scaled(24))
+                .padding(.horizontal, scaled(12))
                 .padding(.bottom, scaled(40))
             }
         }

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodFollowUpView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodFollowUpView.swift
@@ -25,7 +25,7 @@ struct MoodFollowUpView: View {
                     .font(.title3.weight(.semibold))
                     .foregroundColor(.white)
             }
-            .padding(.horizontal, scaled(42))
+            .padding(.horizontal, scaled(21))
             .padding(.top, scaled(20))
 
             VStack(spacing: 0) {
@@ -79,7 +79,7 @@ struct MoodFollowUpView: View {
                                 .buttonStyle(.plain)
                             }
                         }
-                        .padding(.horizontal, scaled(24))
+                        .padding(.horizontal, scaled(12))
 
                         // Note section
                         Text("Anything you want to jot down?")
@@ -105,7 +105,7 @@ struct MoodFollowUpView: View {
                             RoundedRectangle(cornerRadius: scaled(12))
                                 .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                         )
-                        .padding(.horizontal, scaled(24))
+                        .padding(.horizontal, scaled(12))
                     }
                     .padding(.bottom, scaled(24))
                 }
@@ -126,7 +126,7 @@ struct MoodFollowUpView: View {
                         .cornerRadius(scaled(30))
                 }
                 .disabled(followUpScore == 0)
-                .padding(.horizontal, scaled(24))
+                .padding(.horizontal, scaled(12))
                 .padding(.bottom, scaled(40))
             }
         }

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodHistoryView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodHistoryView.swift
@@ -169,7 +169,8 @@ struct MoodHistoryView: View {
                         daysToDisplay: daysToDisplay
                     )
                 }
-                .padding()
+                .padding(.vertical)
+                .padding(.horizontal, scaled(8))
             }
             .refreshable {
                 await loadHistoryAsync()

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodLogView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodLogView.swift
@@ -120,7 +120,7 @@ private struct MoodLogContent: View {
                     }
                     footer
                 }
-                .padding(.horizontal, scaled(20))
+                .padding(.horizontal, scaled(10))
                 .padding(.vertical, scaled(24))
             }
             .scrollContentBackground(.hidden)

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodResponseView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodResponseView.swift
@@ -234,7 +234,7 @@ struct MoodResponseView: View {
     var body: some View {
         ScrollView {
             MoodResponseContent(response: response, onDismiss: onDismiss)
-                .padding()
+                .padding(.vertical).padding(.horizontal, scaled(8))
         }
     }
 }

--- a/WalkWorthy/WalkWorthy/UI/Mood/MoodSliderView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Mood/MoodSliderView.swift
@@ -42,7 +42,7 @@ struct MoodSliderView: View {
                 // Mood slider
                 Slider(value: $sliderValue, in: 0...1)
                     .accentColor(.white)
-                    .padding(.horizontal, scaled(24))
+                    .padding(.horizontal, scaled(12))
                     .onChange(of: sliderValue) {
                         checkHapticSnap()
                     }
@@ -55,7 +55,7 @@ struct MoodSliderView: View {
                 }
                 .font(.caption)
                 .foregroundColor(.white.opacity(0.8))
-                .padding(.horizontal, scaled(24))
+                .padding(.horizontal, scaled(12))
                 .padding(.top, scaled(4))
 
                 // Next button
@@ -68,7 +68,7 @@ struct MoodSliderView: View {
                         .background(Color.white)
                         .cornerRadius(scaled(30))
                 }
-                .padding(.horizontal, scaled(24))
+                .padding(.horizontal, scaled(12))
                 .padding(.top, scaled(24))
                 .padding(.bottom, scaled(40))
             }

--- a/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
+++ b/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
@@ -66,7 +66,7 @@ struct OnboardingForm: View {
                     primaryButton
                 }
                 .padding(.vertical, scaled(32))
-                .padding(.horizontal, scaled(24))
+                .padding(.horizontal, scaled(12))
             }
             .scrollContentBackground(.hidden)
         }


### PR DESCRIPTION
## Summary

Layout pass across iPhone 17 (402pt), iPhone 17 Pro (402pt), and iPhone 17 Pro Max (440pt): fixes the reported "add new note button clipping on the right wall," fixes a chip-wrapping bug found during the audit, and halves the horizontal page margins app-wide per design feedback.

### Fix 1 — Journal compose button clipped off the right edge (reported bug)

**Root cause:** `DynamicBackgroundView`'s hero image used `.scaledToFill().frame(height: scaled(280))` with no width constraint. A fixed frame with only a height reports its width as `height × image aspect ratio` (~444pt — wider than any iPhone), and `.clipped()` only clips *drawing*, not *layout*. The oversized layout width inflated the enclosing `ZStack` on every screen using the background, dragging `.bottomTrailing`-aligned siblings — the Journal compose button — past the screen edge on **all** devices.

**Fix:** the fill image now lives in an `.overlay` of a `Color.clear` fixed-height frame, so the layout width always equals the proposed width while the image still fills and crops visually. One-view change; every screen using `DynamicBackgroundView` inherits the fix.

**Verified** (pixel-measured from simulator screenshots): compose button right gap was `0pt` (circle partially off-screen); now renders at its declared padding on all three devices.

### Fix 2 — Emotion/category chips hyphen-broke mid-word on 402pt phones

"Overwhelmed" / "Disappointed" rendered as "Over-whelmed" / "Disappoint-ed" inside the check-in wizard grids on iPhone 17 / 17 Pro (fine on Pro Max). Chips are now single-line with `minimumScaleFactor(0.8)`, matching the Pro Max appearance on all sizes.

### Design change — horizontal page margins halved app-wide

Per design feedback, every screen-level horizontal inset is now half its previous value:

| Screen | Before | After |
|---|---|---|
| Home | scaled(24) | scaled(12) |
| Mood History | 16 (default) | scaled(8) |
| Check-in log | scaled(20) | scaled(10) |
| Journal editor | scaled(32) | scaled(16) |
| Onboarding form | scaled(24) | scaled(12) |
| Sign-in panel | scaled(24) | scaled(12) |
| Mood wizard content + buttons | scaled(24) | scaled(12) |
| Mood wizard back chevron | scaled(42) | scaled(21) |
| Response cards | 16 / scaled(16) | scaled(8) |
| Journal compose button (trailing) | scaled(20) | scaled(10) |

Card interiors, chip padding, and system-managed insets (Settings `Form`, Journal inset-grouped `List`) are unchanged.

## Audit coverage

All 13 screens screenshot-verified on all three simulators (Home, History, Journal list + editor, Settings, Check-in log, mood wizard: slider / tags / categories / follow-up / response, Onboarding, Title/Sign-in), re-verified after each change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)